### PR TITLE
Fix P2P Public Key

### DIFF
--- a/utils/account_test.go
+++ b/utils/account_test.go
@@ -71,10 +71,31 @@ func TestCreateP2PKey(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	pubKey := ed25519.PrivKeyBytesToPubKeyBytes(key.PrivateKey)
-	bechPub, err := bech32.ConvertAndEncode(hrp, pubKey)
+	pubKey := ed25519.PrivKeyBytesToPubKey(key.PrivateKey)
+	bechPub, err := bech32.ConvertAndEncode(hrp, pubKey.Bytes())
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	fmt.Printf("Address: %v  PublicKey: %v", bechAddr, bechPub)
+}
+
+func TestDecryptP2PKeyJson(t *testing.T) {
+	hrp := "stsdsp2p"
+	key, err := DecryptKey([]byte("put the content of the P2P key JSON file here"), "aaa")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	pubKey := ed25519.PrivKeyBytesToPubKey(key.PrivateKey)
+	bechPub, err := bech32.ConvertAndEncode(hrp, pubKey.Bytes())
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	bechAddr, err := bech32.ConvertAndEncode(hrp, pubKey.Address().Bytes())
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
 	fmt.Printf("Address: %v  PublicKey: %v", bechAddr, bechPub)
 }


### PR DESCRIPTION
This PR changes the way the bech encoded P2P public key string is generated.

Stratos-chain expects a 37 bytes public key, which is an amino serialized tendermint crypto.PubKey object, instead of the actual 32 bytes of public key.