### PR TITLE
QB-641 relayd reconnects to SP node when connection fails

### DIFF
--- a/cmd/ppd/node.go
+++ b/cmd/ppd/node.go
@@ -94,11 +94,11 @@ func SetupP2PKey() error {
 		if err != nil {
 			return errors.New("couldn't read password from console: " + err.Error())
 		}
-		confimation, err := console.Stdin.PromptPassword("Enter password again: ")
+		confirmation, err := console.Stdin.PromptPassword("Enter password again: ")
 		if err != nil {
 			return errors.New("couldn't read confirmation password from console: " + err.Error())
 		}
-		if password != confimation {
+		if password != confirmation {
 			return errors.New("invalid. The two passwords don't match")
 		}
 

--- a/cmd/relayd/config/config-template.yaml
+++ b/cmd/relayd/config/config-template.yaml
@@ -4,10 +4,13 @@ sds:
   websocketPort: 8889
   connectionRetries:
     max: 100
-    sleepDuration: 1000 # milliseconds
+    sleepDuration: 3000 # milliseconds
 stratosChain:
   restServer: 127.0.0.1:1317
   websocketServer: 127.0.0.1:26657
+  connectionRetries:
+    max: 100
+    sleepDuration: 3000 # milliseconds
 blockchainInfo:
   addressPrefix: st
   p2pAddressPrefix: stsdsp2p

--- a/cmd/relayd/config/setting.go
+++ b/cmd/relayd/config/setting.go
@@ -18,8 +18,9 @@ type sds struct {
 }
 
 type stratoschain struct {
-	RestServer      string `yaml:"restServer"`
-	WebsocketServer string `yaml:"websocketServer"`
+	RestServer        string            `yaml:"restServer"`
+	WebsocketServer   string            `yaml:"websocketServer"`
+	ConnectionRetries connectionRetries `yaml:"connectionRetries"`
 }
 
 type config struct {

--- a/cmd/relayd/relayd.go
+++ b/cmd/relayd/relayd.go
@@ -41,6 +41,7 @@ func main() {
 	for {
 		select {
 		case <-quit:
+			utils.Log("Quit signal detected. Shutting down...")
 			return
 		case <-multiClient.Ctx.Done():
 			return


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-641

- When the connection to SP node fails, relayd will try to reconnect, and shutdown if reconnecting fails too many times
- Connecting to stratos-chain is now on a loop as well. The node will only shutdown if the max retries is reached
- Relayd properly shuts down for SIGTERM and other signals. It won't hang forever if the stratos-chain or SDS connection is unresponsive