### PR TITLE
QB-645 Change stratos-chain URL config

### DIFF
--- a/cmd/relayd/config/config-template.yaml
+++ b/cmd/relayd/config/config-template.yaml
@@ -6,7 +6,7 @@ sds:
     max: 100
     sleepDuration: 3000 # milliseconds
 stratosChain:
-  restServer: 127.0.0.1:1317
+  restServer: http://127.0.0.1:1317
   websocketServer: 127.0.0.1:26657
   connectionRetries:
     max: 100

--- a/example/network/node1/configs/config.yaml
+++ b/example/network/node1/configs/config.yaml
@@ -28,8 +28,7 @@ AddressPrefix: "st"
 P2PKeyPrefix: "stsdsp2p"
 ChainId: "test-chain"
 Token: "ustos"
-StratosChainAddress: 127.0.0.1
-StratosChainPort: 1317
+StratosChainUrl: http://127.0.0.1:1317
 RestPort: 18091
 InternalPort: 9608
 StreamingCache: false

--- a/example/network/node2/configs/config.yaml
+++ b/example/network/node2/configs/config.yaml
@@ -28,8 +28,7 @@ AddressPrefix: "st"
 P2PKeyPrefix: "stsdsp2p"
 ChainId: "test-chain"
 Token: "ustos"
-StratosChainAddress: 127.0.0.1
-StratosChainPort: 1317
+StratosChainUrl: http://127.0.0.1:1317
 RestPort:
 InternalPort:
 StreamingCache: false

--- a/pp/setting/setting.go
+++ b/pp/setting/setting.go
@@ -105,8 +105,7 @@ type config struct {
 	P2PKeyPrefix                string `yaml:"P2PKeyPrefix"`
 	ChainId                     string `yaml:"ChainId"`
 	Token                       string `yaml:"Token"`
-	StratosChainAddress         string `yaml:"StratosChainAddress"`
-	StratosChainPort            string `yaml:"StratosChainPort"`
+	StratosChainUrl             string `yaml:"StratosChainUrl"`
 	StreamingCache              bool   `yaml:"StreamingCache"`
 	RestPort                    string `yaml:"RestPort"`
 	InternalPort                string `yaml:"InternalPort"`
@@ -134,7 +133,7 @@ func LoadConfig(configPath string) error {
 	cf.SetLimitDownloadSpeed(Config.LimitDownloadSpeed, Config.IsLimitDownloadSpeed)
 	cf.SetLimitUploadSpeed(Config.LimitUploadSpeed, Config.IsLimitUploadSpeed)
 	prefix.SetConfig(Config.AddressPrefix)
-	stratoschain.Url = "http://" + Config.StratosChainAddress + ":" + Config.StratosChainPort
+	stratoschain.Url = Config.StratosChainUrl
 	return nil
 }
 
@@ -273,8 +272,7 @@ func defaultConfig() *config {
 		P2PKeyPrefix:                "stsdsp2p",
 		ChainId:                     "stratos-testnet-2",
 		Token:                       "ustos",
-		StratosChainAddress:         "127.0.0.1",
-		StratosChainPort:            "1317",
+		StratosChainUrl:             "http://127.0.0.1:1317",
 		StreamingCache:              false,
 		RestPort:                    "",
 		InternalPort:                "",

--- a/relay/client/client.go
+++ b/relay/client/client.go
@@ -48,8 +48,7 @@ func NewClient() *MultiClient {
 
 func (m *MultiClient) Start() error {
 	// REST client to send messages to stratos-chain
-	scRestUrl := "http://" + setting.Config.StratosChain.RestServer
-	stratoschain.Url = scRestUrl
+	stratoschain.Url = setting.Config.StratosChain.RestServer
 	// Client to subscribe to stratos-chain events and receive messages via websocket
 	m.stratosWebsocketUrl = setting.Config.StratosChain.WebsocketServer
 


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-645
Change the stratos-chain URL config for PP nodes and relayd. Previously a hardcoded "http://" was added to the URL from the config, so it wasn't possible to call an https endpoint on port 443