### PR TITLE
fix/qb-687: set stratoschain URL in relayd

### DIFF
--- a/relay/client/client.go
+++ b/relay/client/client.go
@@ -48,6 +48,8 @@ func NewClient() *MultiClient {
 }
 
 func (m *MultiClient) Start() error {
+	// REST client to send messages to stratos-chain
+	stratoschain.Url = setting.Config.StratosChain.RestServer
 	// Client to subscribe to stratos-chain events and receive messages via websocket
 	m.stratosWebsocketUrl = setting.Config.StratosChain.WebsocketServer
 


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-687
During the refactoring we removed the line that sets the stratoschain URL in relayd. This line is still needed for relayd to broadcast transactions.