### PR TITLE
fix/QB-718 use same bip39 passphrase as wallet app

### DIFF
--- a/cmd/ppd/config.go
+++ b/cmd/ppd/config.go
@@ -89,7 +89,7 @@ func SetupWalletKey() error {
 		}
 		//hrp, mnemonic, bip39Passphrase, hdPath
 		walletKeyAddress, err := utils.CreateWallet(setting.Config.AccountDir, nickname, password,
-			setting.Config.AddressPrefix, mnemonic, "mnemonic", hdPath, setting.Config.ScryptN, setting.Config.ScryptP)
+			setting.Config.AddressPrefix, mnemonic, "", hdPath, setting.Config.ScryptN, setting.Config.ScryptP)
 		if err != nil {
 			return errors.New("couldn't create WalletAddress: " + err.Error())
 		}

--- a/cmd/ppd/config.go
+++ b/cmd/ppd/config.go
@@ -89,7 +89,7 @@ func SetupWalletKey() error {
 		}
 		//hrp, mnemonic, bip39Passphrase, hdPath
 		walletKeyAddress, err := utils.CreateWallet(setting.Config.AccountDir, nickname, password,
-			setting.Config.AddressPrefix, mnemonic, "", hdPath, setting.Config.ScryptN, setting.Config.ScryptP)
+			setting.Config.AddressPrefix, mnemonic, "", hdPath)
 		if err != nil {
 			return errors.New("couldn't create WalletAddress: " + err.Error())
 		}

--- a/cmd/ppd/node.go
+++ b/cmd/ppd/node.go
@@ -102,7 +102,7 @@ func SetupP2PKey() error {
 		}
 
 		p2pKeyAddress, err := utils.CreateP2PKey(setting.Config.AccountDir, nickname, password,
-			setting.Config.P2PKeyPrefix, setting.Config.ScryptN, setting.Config.ScryptP)
+			setting.Config.P2PKeyPrefix)
 		if err != nil {
 			return errors.New("couldn't create WalletAddress: " + err.Error())
 		}

--- a/cmd/ppd/terminal.go
+++ b/cmd/ppd/terminal.go
@@ -77,7 +77,7 @@ func terminal(cmd *cobra.Command, args []string) {
 		}
 
 		mnemonic := console.MyGetPassword("input bip39 mnemonic (leave blank to generate a new one)", false)
-		passphrase := console.MyGetPassword("input bip39 passphrase", false)
+		passphrase := console.MyGetPassword("input bip39 passphrase (most users should leave this blank)", false)
 
 		serv.CreateWallet(password, param[0], mnemonic, passphrase, param[1])
 		return true

--- a/cmd/ppd/terminal.go
+++ b/cmd/ppd/terminal.go
@@ -77,9 +77,8 @@ func terminal(cmd *cobra.Command, args []string) {
 		}
 
 		mnemonic := console.MyGetPassword("input bip39 mnemonic (leave blank to generate a new one)", false)
-		passphrase := console.MyGetPassword("input bip39 passphrase (most users should leave this blank)", false)
 
-		serv.CreateWallet(password, param[0], mnemonic, passphrase, param[1])
+		serv.CreateWallet(password, param[0], mnemonic, "", param[1])
 		return true
 	}
 

--- a/example/network/node1/configs/config.yaml
+++ b/example/network/node1/configs/config.yaml
@@ -6,8 +6,6 @@ NetworkAddress: 127.0.0.1
 Debug: true
 PPListDir: ./peers
 AccountDir: ./accounts
-scryptN: 4096
-scryptP: 6
 DefPassword: ""
 DefSavePath: ""
 StorehousePath: ""

--- a/example/network/node2/configs/config.yaml
+++ b/example/network/node2/configs/config.yaml
@@ -6,8 +6,6 @@ NetworkAddress: 127.0.0.1
 Debug: true
 PPListDir: ./peers
 AccountDir: ./accounts
-scryptN: 4096
-scryptP: 6
 DefPassword: ""
 DefSavePath: ""
 StorehousePath: ""

--- a/pp/api/change_password.go
+++ b/pp/api/change_password.go
@@ -70,7 +70,7 @@ func changePassword(w http.ResponseWriter, request *http.Request) {
 		w.Write(httpserv.NewJson(nil, setting.FAILCode, "new password not match").ToBytes())
 		return
 	}
-	err = utils.ChangePassword(walletAddress, dir, newPassWord, setting.Config.ScryptN, setting.Config.ScryptP, key)
+	err = utils.ChangePassword(walletAddress, dir, newPassWord, key)
 	if err != nil {
 		w.Write(httpserv.NewJson(nil, setting.FAILCode, "failed to change password").ToBytes())
 		return

--- a/pp/api/create_wallet.go
+++ b/pp/api/create_wallet.go
@@ -68,7 +68,7 @@ func createWallet(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 	walletAddress, err := utils.CreateWallet(setting.Config.AccountDir, name, password, setting.Config.AddressPrefix,
-		mnemonic, passphrase, hdPath, setting.Config.ScryptN, setting.Config.ScryptP)
+		mnemonic, passphrase, hdPath)
 	if err != nil {
 		w.Write(httpserv.NewJson(nil, setting.FAILCode, "failed to create wallet").ToBytes())
 		return

--- a/pp/api/import_wallet.go
+++ b/pp/api/import_wallet.go
@@ -48,7 +48,7 @@ func importWallet(w http.ResponseWriter, request *http.Request) {
 		w.Write(httpserv.NewJson(nil, setting.FAILCode, "failed to convert wallet address to bech32 string").ToBytes())
 		return
 	}
-	ks := utils.KeyStorePassphrase{dir, setting.Config.ScryptN, setting.Config.ScryptP}
+	ks := utils.KeyStorePassphrase{dir, utils.ScryptN, utils.ScryptP}
 	filename := dir + "/" + setting.WalletAddress + ".json"
 	err = ks.StoreKey(filename, key, password)
 	if err != nil {

--- a/pp/api/import_wallet.go
+++ b/pp/api/import_wallet.go
@@ -48,7 +48,7 @@ func importWallet(w http.ResponseWriter, request *http.Request) {
 		w.Write(httpserv.NewJson(nil, setting.FAILCode, "failed to convert wallet address to bech32 string").ToBytes())
 		return
 	}
-	ks := utils.KeyStorePassphrase{dir, utils.ScryptN, utils.ScryptP}
+	ks := utils.GetKeyStorePassphrase(dir)
 	filename := dir + "/" + setting.WalletAddress + ".json"
 	err = ks.StoreKey(filename, key, password)
 	if err != nil {

--- a/pp/serv/account.go
+++ b/pp/serv/account.go
@@ -24,7 +24,7 @@ func CreateWallet(password, name, mnemonic, passphrase, hdPath string) string {
 		mnemonic = newMnemonic
 	}
 	account, err := utils.CreateWallet(setting.Config.AccountDir, name, password, setting.Config.AddressPrefix,
-		mnemonic, passphrase, hdPath, setting.Config.ScryptN, setting.Config.ScryptP)
+		mnemonic, passphrase, hdPath)
 	if utils.CheckError(err) {
 		utils.ErrorLog("CreateWallet error", err)
 		return ""

--- a/pp/setting/setting.go
+++ b/pp/setting/setting.go
@@ -89,8 +89,6 @@ type config struct {
 	Debug                       bool         `yaml:"Debug"`
 	PPListDir                   string       `yaml:"PPListDir"`
 	AccountDir                  string       `yaml:"AccountDir"`
-	ScryptN                     int          `yaml:"scryptN"`
-	ScryptP                     int          `yaml:"scryptP"`
 	DefPassword                 string       `yaml:"DefPassword"`
 	DefSavePath                 string       `yaml:"DefSavePath"`
 	StorehousePath              string       `yaml:"StorehousePath"`
@@ -268,8 +266,6 @@ func defaultConfig() *config {
 		Debug:                       false,
 		PPListDir:                   "./peers",
 		AccountDir:                  "./accounts",
-		ScryptN:                     4096,
-		ScryptP:                     6,
 		DefPassword:                 "",
 		DefSavePath:                 "",
 		StorehousePath:              "",

--- a/utils/account_test.go
+++ b/utils/account_test.go
@@ -20,7 +20,7 @@ func TestCreateWallet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	addr, err := CreateWallet("keys", "", password, hrp, mnemonic, "passphrase", "44'/606'/0'/0/44", 4096, 6)
+	addr, err := CreateWallet("keys", "", password, hrp, mnemonic, "passphrase", "44'/606'/0'/0/44")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -53,7 +53,7 @@ func TestCreateP2PKey(t *testing.T) {
 	password := "aaa"
 	hrp := "stsdsp2p"
 
-	addr, err := CreateP2PKey("keys", "", password, hrp, 4096, 6)
+	addr, err := CreateP2PKey("keys", "", password, hrp)
 	if err != nil {
 		t.Fatal(err.Error())
 	}


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-718

Use an empty string as bip39 passphrase when creating new wallets. This matches the bip39 passphrase that is used in the wallet app and in stchain.