### PR TITLE
Feat/QB-706 default scheme and port config for URLs

### DIFF
--- a/relay/client/stratoschain_events.go
+++ b/relay/client/stratoschain_events.go
@@ -355,8 +355,14 @@ func postToSP(endpoint string, data interface{}) error {
 		return errors.New("Error when trying to marshal data to json: " + err.Error())
 	}
 
-	sdsApiUrl := "http://" + setting.Config.SDS.NetworkAddress + ":" + setting.Config.SDS.ApiPort
-	resp, err := http.Post(sdsApiUrl+endpoint, "application/json", bytes.NewBuffer(jsonData))
+	url := utils.Url{
+		Scheme: "http",
+		Host:   setting.Config.SDS.NetworkAddress,
+		Port:   setting.Config.SDS.ApiPort,
+		Path:   endpoint,
+	}
+
+	resp, err := http.Post(url.String(true, true, true), "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
 		return errors.New("Error when calling " + endpoint + " endpoint in SP node: " + err.Error())
 	}

--- a/relay/stratoschain/rest.go
+++ b/relay/stratoschain/rest.go
@@ -57,7 +57,11 @@ func FetchAccountInfo(address string) (uint64, uint64, error) {
 		return 0, 0, errors.New("the stratos-chain URL is not set")
 	}
 
-	resp, err := http.Get(Url + "/auth/accounts/" + address)
+	url, err := utils.ParseUrl(Url + "/auth/accounts/" + address)
+	if err != nil {
+		return 0, 0, err
+	}
+	resp, err := http.Get(url.String(true, true, true))
 	if err != nil {
 		return 0, 0, err
 	}
@@ -154,6 +158,11 @@ func BroadcastTx(tx authtypes.StdTx) (*http.Response, []byte, error) {
 		return nil, nil, errors.New("the stratos-chain URL is not set")
 	}
 
+	url, err := utils.ParseUrl(Url + "/txs")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	body := rest.BroadcastReq{
 		Tx:   tx,
 		Mode: "sync",
@@ -164,7 +173,7 @@ func BroadcastTx(tx authtypes.StdTx) (*http.Response, []byte, error) {
 	}
 
 	bodyBytes := bytes.NewBuffer(jsonBytes)
-	resp, err := http.Post(Url+"/txs", "application/json", bodyBytes)
+	resp, err := http.Post(url.String(true, true, true), "application/json", bodyBytes)
 	if err != nil {
 		return resp, nil, err
 	}
@@ -178,8 +187,13 @@ func BroadcastTxBytes(txBytes []byte) error {
 		return errors.New("the stratos-chain URL is not set")
 	}
 
+	url, err := utils.ParseUrl(Url + "/txs")
+	if err != nil {
+		return err
+	}
+
 	bodyBytes := bytes.NewBuffer(txBytes)
-	resp, err := http.Post(Url+"/txs", "application/json", bodyBytes)
+	resp, err := http.Post(url.String(true, true, true), "application/json", bodyBytes)
 	if err != nil {
 		return err
 	}
@@ -199,7 +213,12 @@ func QueryResourceNodeState(p2pAddress string) (int, error) {
 		return 0, errors.New("the stratos-chain URL is not set")
 	}
 
-	resp, err := http.Get(Url + "/register/resource-nodes?moniker=" + p2pAddress)
+	url, err := utils.ParseUrl(Url + "/register/resource-nodes?moniker=" + p2pAddress)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := http.Get(url.String(true, true, true))
 	if err != nil {
 		return 0, err
 	}

--- a/relay/stratoschain/websocket.go
+++ b/relay/stratoschain/websocket.go
@@ -2,11 +2,18 @@ package stratoschain
 
 import (
 	"errors"
+
+	"github.com/stratosnet/sds/utils"
 	tmhttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
 func DialWebsocket(addr string) (*tmhttp.HTTP, error) {
-	client, err := tmhttp.New("tcp://"+addr, "/websocket")
+	url, err := utils.ParseUrl(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := tmhttp.New(url.String(true, true, false), "/websocket")
 	if err != nil {
 		return nil, errors.New("failed to create stratos-chain Client: " + err.Error())
 	}

--- a/utils/url.go
+++ b/utils/url.go
@@ -1,0 +1,85 @@
+package utils
+
+import (
+	netUrl "net/url"
+	"strings"
+)
+
+type Url struct {
+	Scheme string
+	Host   string
+	Port   string
+	Path   string
+}
+
+func ParseUrl(url string) (*Url, error) {
+	splitUrl := strings.Split(url, "://")
+	missingScheme := false
+	if len(splitUrl) == 1 {
+		url = "http://" + url
+		missingScheme = true
+	}
+
+	parsedNetUrl, err := netUrl.Parse(url)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedUrl := &Url{
+		Scheme: parsedNetUrl.Scheme,
+		Host:   parsedNetUrl.Host,
+		Path:   parsedNetUrl.Path,
+	}
+
+	if missingScheme {
+		parsedUrl.Scheme = ""
+	}
+
+	splitHost := strings.Split(parsedUrl.Host, ":")
+	if len(splitHost) == 2 {
+		parsedUrl.Host = splitHost[0]
+		parsedUrl.Port = splitHost[1]
+	}
+
+	// Default values
+	if parsedUrl.Scheme == "" {
+		if parsedUrl.Port == "443" {
+			parsedUrl.Scheme = "https"
+		} else {
+			parsedUrl.Scheme = "http"
+		}
+	}
+
+	if parsedUrl.Port == "" {
+		if parsedUrl.Scheme == "https" {
+			parsedUrl.Port = "443"
+		} else {
+			parsedUrl.Port = "80"
+		}
+	}
+
+	return parsedUrl, nil
+}
+
+func (url *Url) String(withScheme, withPort, withPath bool) string {
+	urlString := ""
+	if withScheme && url.Scheme != "" {
+		urlString = url.Scheme + "://"
+	}
+
+	urlString = urlString + url.Host
+
+	if withPort && url.Port != "" {
+		urlString = urlString + ":" + url.Port
+	}
+
+	if withPath && url.Path != "" {
+		separator := "/"
+		if url.Path[0] == '/' {
+			separator = ""
+		}
+		urlString = urlString + separator + url.Path
+	}
+
+	return urlString
+}

--- a/utils/url_test.go
+++ b/utils/url_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestParseURL(t *testing.T) {
+	url, err := ParseUrl("http://www.fake.host:123/random/path")
+	verifyUrl(t, url, err)
+	verifyUrlString(t, url, true, true, true, "http://www.fake.host:123/random/path")
+}
+
+func TestParseURLInvalid(t *testing.T) {
+	_, err := ParseUrl("http://www.fake.host:wrongport/random/path")
+	if err == nil {
+		t.Fatal("The port is wrong so an error was expected")
+	}
+}
+
+func TestParseURLMissingScheme(t *testing.T) {
+	url, err := ParseUrl("www.fake.host:80/random/path")
+	verifyUrl(t, url, err)
+	verifyUrlString(t, url, true, true, false, "http://www.fake.host:80")
+
+	url, err = ParseUrl("www.fake.host:443/random/path")
+	verifyUrl(t, url, err)
+	verifyUrlString(t, url, true, true, false, "https://www.fake.host:443")
+}
+
+func TestParseURLMissingPort(t *testing.T) {
+	url, err := ParseUrl("http://www.fake.host/random/path")
+	verifyUrl(t, url, err)
+	verifyUrlString(t, url, true, true, false, "http://www.fake.host:80")
+
+	url, err = ParseUrl("https://www.fake.host/random/path")
+	verifyUrl(t, url, err)
+	verifyUrlString(t, url, true, true, false, "https://www.fake.host:443")
+}
+
+func TestPrintURL(t *testing.T) {
+	url, err := ParseUrl("tcp://www.fake.host:123/random/path")
+	verifyUrl(t, url, err)
+	verifyUrlString(t, url, false, true, true, "www.fake.host:123/random/path")
+	verifyUrlString(t, url, true, false, true, "tcp://www.fake.host/random/path")
+	verifyUrlString(t, url, true, true, false, "tcp://www.fake.host:123")
+	verifyUrlString(t, url, false, false, false, "www.fake.host")
+}
+
+func verifyUrl(t *testing.T, url *Url, err error) {
+	if err != nil {
+		t.Fatal("unexpected error: " + err.Error())
+	}
+
+	if url == nil {
+		t.Fatal("parsed URL object shouldn't be null")
+	}
+}
+
+func verifyUrlString(t *testing.T, url *Url, scheme, port, path bool, expected string) {
+	urlString := url.String(scheme, port, path)
+	if urlString != expected {
+		t.Fatalf("Wrong URL string. Expected [%v] got [%v]", expected, urlString)
+	}
+}


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-706

- URLs now have default values of http/https for the scheme and 80/443 for port
- No need to specify both https and port 443 at the same time (or http and port 80) in config
- unit tests for URL parsing