### PR TITLE
fix/QB-945 fix relayd for multiple similar txs in same block

### DIFF
--- a/pp/event/get_pplist.go
+++ b/pp/event/get_pplist.go
@@ -17,9 +17,9 @@ import (
 
 // RspGetPPList
 func RspGetPPList(ctx context.Context, conn core.WriteCloser) {
-	utils.DebugLog("get GetPPList RSP")
 	var target protos.RspGetPPList
 	if !requests.UnmarshalData(ctx, &target) {
+		utils.ErrorLog("Couldn't unmarshal protobuf to protos.RspGetPPList")
 		return
 	}
 	utils.DebugLog("get GetPPList RSP", target.PpList)

--- a/relay/client/client.go
+++ b/relay/client/client.go
@@ -265,7 +265,7 @@ func (m *MultiClient) SubscribeToStratosChain(query string, handler func(coretyp
 		return err
 	}
 
-	out, err := client.Subscribe(context.Background(), "", query)
+	out, err := client.Subscribe(context.Background(), "", query, 20)
 	if err != nil {
 		return errors.New("failed to subscribe to query in stratos-chain: " + err.Error())
 	}


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-945

- Make the relayd websocket client (for stchain) buffered, so it can handle multiple transactions of the same type arriving at the same time