### PR TITLE
Fix/gateway pp fix

### DIFF
--- a/pp/event/delete_file.go
+++ b/pp/event/delete_file.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
-	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
@@ -19,7 +18,7 @@ import (
 // DeleteFile
 func DeleteFile(fileHash, reqID string, w http.ResponseWriter) {
 	if setting.CheckLogin() {
-		peers.SendMessage(client.PPConn, requests.ReqDeleteFileData(fileHash, reqID), header.ReqDeleteFile)
+		peers.SendMessageDirectToSPOrViaPP(requests.ReqDeleteFileData(fileHash, reqID), header.ReqDeleteFile)
 		storeResponseWriter(reqID, w)
 	} else {
 		notLogin(w)
@@ -43,7 +42,7 @@ func RspDeleteFile(ctx context.Context, conn core.WriteCloser) {
 			}
 			putData(target.ReqId, HTTPDeleteFile, &target)
 		} else {
-			peers.TransferSendMessageToClient(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 }

--- a/pp/event/delete_file.go
+++ b/pp/event/delete_file.go
@@ -42,7 +42,7 @@ func RspDeleteFile(ctx context.Context, conn core.WriteCloser) {
 			}
 			putData(target.ReqId, HTTPDeleteFile, &target)
 		} else {
-			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 }

--- a/pp/event/download_slice.go
+++ b/pp/event/download_slice.go
@@ -121,7 +121,7 @@ func RspDownloadSlice(ctx context.Context, conn core.WriteCloser) {
 						conn := c.(*core.ServerConn)
 						conn.Write(core.MessageFromContext(ctx))
 					} else {
-						peers.TransferSendMessageToClient(target.P2PAddress, core.MessageFromContext(ctx))
+						peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
 					}
 					if target.NeedReport {
 						utils.DebugLog("arget.NeedReportarget.NeedReportarget.NeedReportarget.NeedReport")
@@ -374,7 +374,7 @@ func ReqDownloadSlicePause(ctx context.Context, conn core.WriteCloser) {
 	utils.DebugLog("ReqDownloadSlicePause&*************************************** ")
 	var target protos.ReqDownloadSlicePause
 	if requests.UnmarshalData(ctx, &target) {
-		peers.TransferSendMessageToClient(target.P2PAddress, requests.RspDownloadSlicePauseData(&target))
+		peers.TransferSendMessageToPPServ(target.P2PAddress, requests.RspDownloadSlicePauseData(&target))
 		//
 		if dlTask, ok := task.DownloadTaskMap.Load(target.FileHash + target.WalletAddress); ok {
 			downloadTask := dlTask.(*task.DownloadTask)

--- a/pp/event/download_slice.go
+++ b/pp/event/download_slice.go
@@ -121,7 +121,7 @@ func RspDownloadSlice(ctx context.Context, conn core.WriteCloser) {
 						conn := c.(*core.ServerConn)
 						conn.Write(core.MessageFromContext(ctx))
 					} else {
-						peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
+						peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
 					}
 					if target.NeedReport {
 						utils.DebugLog("arget.NeedReportarget.NeedReportarget.NeedReportarget.NeedReport")
@@ -374,7 +374,7 @@ func ReqDownloadSlicePause(ctx context.Context, conn core.WriteCloser) {
 	utils.DebugLog("ReqDownloadSlicePause&*************************************** ")
 	var target protos.ReqDownloadSlicePause
 	if requests.UnmarshalData(ctx, &target) {
-		peers.TransferSendMessageToPPServ(target.P2PAddress, requests.RspDownloadSlicePauseData(&target))
+		peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, requests.RspDownloadSlicePauseData(&target))
 		//
 		if dlTask, ok := task.DownloadTaskMap.Load(target.FileHash + target.WalletAddress); ok {
 			downloadTask := dlTask.(*task.DownloadTask)

--- a/pp/event/find_file.go
+++ b/pp/event/find_file.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
-	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
 	"github.com/stratosnet/sds/pp/setting"
@@ -17,7 +16,7 @@ import (
 // FindMyFileList
 func FindMyFileList(fileName, dir, reqID, keyword string, fileType int, isUp bool, w http.ResponseWriter) {
 	if setting.CheckLogin() {
-		peers.SendMessage(client.PPConn, requests.FindMyFileListData(fileName, dir, reqID, keyword, protos.FileSortType(fileType), isUp), header.ReqFindMyFileList)
+		peers.SendMessageDirectToSPOrViaPP(requests.FindMyFileListData(fileName, dir, reqID, keyword, protos.FileSortType(fileType), isUp), header.ReqFindMyFileList)
 		storeResponseWriter(reqID, w)
 	} else {
 		notLogin(w)
@@ -39,7 +38,7 @@ func RspFindMyFileList(ctx context.Context, conn core.WriteCloser) {
 	}
 
 	if target.P2PAddress != setting.P2PAddress {
-		peers.TransferSendMessageToClient(target.P2PAddress, core.MessageFromContext(ctx))
+		peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
 		return
 	}
 

--- a/pp/event/find_file.go
+++ b/pp/event/find_file.go
@@ -38,7 +38,7 @@ func RspFindMyFileList(ctx context.Context, conn core.WriteCloser) {
 	}
 
 	if target.P2PAddress != setting.P2PAddress {
-		peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
+		peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
 		return
 	}
 

--- a/pp/event/query_file_info.go
+++ b/pp/event/query_file_info.go
@@ -25,7 +25,7 @@ func GetFileStorageInfo(path, savePath, reqID string, isVideoStream bool, w http
 	if setting.CheckLogin() {
 		if CheckDownloadPath(path) {
 			utils.DebugLog("path:", path)
-			peers.SendMessage(client.PPConn, requests.ReqFileStorageInfoData(path, savePath, reqID, isVideoStream, nil), header.ReqFileStorageInfo)
+			peers.SendMessageDirectToSPOrViaPP(requests.ReqFileStorageInfoData(path, savePath, reqID, isVideoStream, nil), header.ReqFileStorageInfo)
 		} else {
 			utils.ErrorLog("please input correct download link, eg: sdm://address/fileHash|filename(optional)")
 			if w != nil {
@@ -155,7 +155,7 @@ func RspFileStorageInfo(ctx context.Context, conn core.WriteCloser) {
 		} else {
 			// store the task and transfer
 			task.AddDownloadTask(&target)
-			peers.TransferSendMessageToClient(target.P2PAddress, requests.RspFileStorageInfoData(&target))
+			peers.TransferSendMessageToPPServ(target.P2PAddress, requests.RspFileStorageInfoData(&target))
 		}
 	}
 }

--- a/pp/event/query_file_info.go
+++ b/pp/event/query_file_info.go
@@ -155,7 +155,7 @@ func RspFileStorageInfo(ctx context.Context, conn core.WriteCloser) {
 		} else {
 			// store the task and transfer
 			task.AddDownloadTask(&target)
-			peers.TransferSendMessageToPPServ(target.P2PAddress, requests.RspFileStorageInfoData(&target))
+			peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, requests.RspFileStorageInfoData(&target))
 		}
 	}
 }

--- a/pp/event/register_chain.go
+++ b/pp/event/register_chain.go
@@ -57,7 +57,7 @@ func RspRegister(ctx context.Context, conn core.WriteCloser) {
 	utils.Log("target.RspRegister", target.P2PAddress)
 	if target.P2PAddress != setting.P2PAddress {
 		utils.Log("transfer RspRegister to: ", target.P2PAddress)
-		peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
+		peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
 		return
 	}
 

--- a/pp/event/register_chain.go
+++ b/pp/event/register_chain.go
@@ -57,7 +57,7 @@ func RspRegister(ctx context.Context, conn core.WriteCloser) {
 	utils.Log("target.RspRegister", target.P2PAddress)
 	if target.P2PAddress != setting.P2PAddress {
 		utils.Log("transfer RspRegister to: ", target.P2PAddress)
-		peers.TransferSendMessageToClient(target.P2PAddress, core.MessageFromContext(ctx))
+		peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
 		return
 	}
 

--- a/pp/event/share.go
+++ b/pp/event/share.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
-	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
 	"github.com/stratosnet/sds/pp/setting"
@@ -17,7 +16,7 @@ import (
 // GetAllShareLink GetShareLink
 func GetAllShareLink(reqID string, w http.ResponseWriter) {
 	if setting.CheckLogin() {
-		peers.SendMessage(client.PPConn, requests.ReqShareLinkData(reqID), header.ReqShareLink)
+		peers.SendMessageDirectToSPOrViaPP(requests.ReqShareLinkData(reqID), header.ReqShareLink)
 		storeResponseWriter(reqID, w)
 	} else {
 		notLogin(w)
@@ -27,7 +26,7 @@ func GetAllShareLink(reqID string, w http.ResponseWriter) {
 // GetReqShareFile GetReqShareFile
 func GetReqShareFile(reqID, fileHash, pathHash string, shareTime int64, isPrivate bool, w http.ResponseWriter) {
 	if setting.CheckLogin() {
-		peers.SendMessage(client.PPConn, requests.ReqShareFileData(reqID, fileHash, pathHash, isPrivate, shareTime), header.ReqShareFile)
+		peers.SendMessageDirectToSPOrViaPP(requests.ReqShareFileData(reqID, fileHash, pathHash, isPrivate, shareTime), header.ReqShareFile)
 		storeResponseWriter(reqID, w)
 	} else {
 		notLogin(w)
@@ -37,7 +36,7 @@ func GetReqShareFile(reqID, fileHash, pathHash string, shareTime int64, isPrivat
 // DeleteShare DeleteShare
 func DeleteShare(shareID, reqID string, w http.ResponseWriter) {
 	if setting.CheckLogin() {
-		peers.SendMessage(client.PPConn, requests.ReqDeleteShareData(reqID, shareID), header.ReqDeleteShare)
+		peers.SendMessageDirectToSPOrViaPP(requests.ReqDeleteShareData(reqID, shareID), header.ReqDeleteShare)
 		storeResponseWriter(reqID, w)
 	} else {
 		notLogin(w)
@@ -73,7 +72,7 @@ func RspShareLink(ctx context.Context, conn core.WriteCloser) {
 			}
 			putData(target.ReqId, HTTPShareLink, &target)
 		} else {
-			peers.TransferSendMessageToClient(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 }
@@ -98,7 +97,7 @@ func RspShareFile(ctx context.Context, conn core.WriteCloser) {
 			}
 			putData(target.ReqId, HTTPShareFile, &target)
 		} else {
-			peers.TransferSendMessageToClient(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 }
@@ -121,7 +120,7 @@ func RspDeleteShare(ctx context.Context, conn core.WriteCloser) {
 			}
 			putData(target.ReqId, HTTPDeleteShare, &target)
 		} else {
-			peers.TransferSendMessageToClient(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 
@@ -131,7 +130,7 @@ func RspDeleteShare(ctx context.Context, conn core.WriteCloser) {
 func GetShareFile(keyword, sharePassword, reqID string, w http.ResponseWriter) {
 	utils.DebugLog("GetShareFile for file ", keyword)
 	if setting.CheckLogin() {
-		peers.SendMessage(client.PPConn, requests.ReqGetShareFileData(keyword, sharePassword, reqID), header.ReqGetShareFile)
+		peers.SendMessageDirectToSPOrViaPP(requests.ReqGetShareFileData(keyword, sharePassword, reqID), header.ReqGetShareFile)
 		storeResponseWriter(reqID, w)
 	} else {
 		notLogin(w)
@@ -153,7 +152,7 @@ func RspGetShareFile(ctx context.Context, _ core.WriteCloser) {
 	}
 
 	if target.ShareRequest.P2PAddress != setting.P2PAddress {
-		peers.TransferSendMessageToClient(target.ShareRequest.P2PAddress, core.MessageFromContext(ctx))
+		peers.TransferSendMessageToPPServ(target.ShareRequest.P2PAddress, core.MessageFromContext(ctx))
 		return
 	}
 
@@ -167,6 +166,6 @@ func RspGetShareFile(ctx context.Context, _ core.WriteCloser) {
 
 	for _, fileInfo := range target.FileInfo {
 		filePath := "sdm://" + fileInfo.OwnerWalletAddress + "/" + fileInfo.FileHash
-		peers.SendMessage(client.PPConn, requests.ReqFileStorageInfoData(filePath, "", "", false, target.ShareRequest), header.ReqFileStorageInfo)
+		peers.SendMessageDirectToSPOrViaPP(requests.ReqFileStorageInfoData(filePath, "", "", false, target.ShareRequest), header.ReqFileStorageInfo)
 	}
 }

--- a/pp/event/share.go
+++ b/pp/event/share.go
@@ -72,7 +72,7 @@ func RspShareLink(ctx context.Context, conn core.WriteCloser) {
 			}
 			putData(target.ReqId, HTTPShareLink, &target)
 		} else {
-			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 }
@@ -97,7 +97,7 @@ func RspShareFile(ctx context.Context, conn core.WriteCloser) {
 			}
 			putData(target.ReqId, HTTPShareFile, &target)
 		} else {
-			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 }
@@ -120,7 +120,7 @@ func RspDeleteShare(ctx context.Context, conn core.WriteCloser) {
 			}
 			putData(target.ReqId, HTTPDeleteShare, &target)
 		} else {
-			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 
@@ -152,7 +152,7 @@ func RspGetShareFile(ctx context.Context, _ core.WriteCloser) {
 	}
 
 	if target.ShareRequest.P2PAddress != setting.P2PAddress {
-		peers.TransferSendMessageToPPServ(target.ShareRequest.P2PAddress, core.MessageFromContext(ctx))
+		peers.TransferSendMessageToPPServByP2pAddress(target.ShareRequest.P2PAddress, core.MessageFromContext(ctx))
 		return
 	}
 

--- a/pp/event/sys_info.go
+++ b/pp/event/sys_info.go
@@ -26,7 +26,7 @@ func ReqGetHDInfo(ctx context.Context, conn core.WriteCloser) {
 		if setting.P2PAddress == target.P2PAddress {
 			peers.SendMessageToSPServer(requests.RspGetHDInfoData(), header.RspGetHDInfo)
 		} else {
-			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 }

--- a/pp/event/sys_info.go
+++ b/pp/event/sys_info.go
@@ -26,7 +26,7 @@ func ReqGetHDInfo(ctx context.Context, conn core.WriteCloser) {
 		if setting.P2PAddress == target.P2PAddress {
 			peers.SendMessageToSPServer(requests.RspGetHDInfoData(), header.RspGetHDInfo)
 		} else {
-			peers.TransferSendMessageToClient(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 }

--- a/pp/event/upload_slice.go
+++ b/pp/event/upload_slice.go
@@ -69,7 +69,7 @@ func RspUploadFileSlice(ctx context.Context, conn core.WriteCloser) {
 		if target.P2PAddress != setting.P2PAddress {
 
 			utils.DebugLog("PP get resp upload slice success, transfer to WalletAddress = ", target.P2PAddress, "sliceNumber= ", target.SliceNumAddr.SliceNumber)
-			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
 		} else {
 			// target is self, report to SP if success
 			utils.DebugLog("P get resp upload slice success sliceNumber", target.SliceNumAddr.SliceNumber, "target.fileHash", target.FileHash)

--- a/pp/event/upload_slice.go
+++ b/pp/event/upload_slice.go
@@ -69,7 +69,7 @@ func RspUploadFileSlice(ctx context.Context, conn core.WriteCloser) {
 		if target.P2PAddress != setting.P2PAddress {
 
 			utils.DebugLog("PP get resp upload slice success, transfer to WalletAddress = ", target.P2PAddress, "sliceNumber= ", target.SliceNumAddr.SliceNumber)
-			peers.TransferSendMessageToClient(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServ(target.P2PAddress, core.MessageFromContext(ctx))
 		} else {
 			// target is self, report to SP if success
 			utils.DebugLog("P get resp upload slice success sliceNumber", target.SliceNumAddr.SliceNumber, "target.fileHash", target.FileHash)

--- a/pp/peers/pp_list.go
+++ b/pp/peers/pp_list.go
@@ -38,10 +38,10 @@ func GetPPList() {
 	SendMessageToSPServer(requests.ReqGetPPlistData(), header.ReqGetPPList)
 }
 
-func SendRegisterRequestViaPP(pplist map[string]*protos.PPBaseInfo) bool {
+func SendRegisterRequestViaPP(pplist []*protos.PPBaseInfo) bool {
 	for _, ppInfo := range pplist {
 		if ppInfo.NetworkAddress == setting.NetworkAddress {
-			setting.DeletePPList(ppInfo.NetworkAddress)
+			setting.DeletePPListByNetworkAddress(ppInfo.NetworkAddress)
 			continue
 		}
 		client.PPConn = client.NewClient(ppInfo.NetworkAddress, true)
@@ -52,7 +52,7 @@ func SendRegisterRequestViaPP(pplist map[string]*protos.PPBaseInfo) bool {
 			return true
 		}
 		utils.DebugLog("failed to conn PP，delete:", ppInfo)
-		setting.DeletePPList(ppInfo.NetworkAddress)
+		setting.DeletePPListByNetworkAddress(ppInfo.NetworkAddress)
 	}
 	return false
 }

--- a/pp/peers/reconnect.go
+++ b/pp/peers/reconnect.go
@@ -33,7 +33,7 @@ func ListenOffline() {
 				}
 			} else {
 				utils.Log("PP is offline")
-				setting.DeletePPList(offline.NetworkAddress)
+				setting.DeletePPListByNetworkAddress(offline.NetworkAddress)
 				InitPPList()
 			}
 		}

--- a/pp/peers/sp_peers.go
+++ b/pp/peers/sp_peers.go
@@ -40,6 +40,14 @@ func SendMessage(conn core.WriteCloser, pb proto.Message, cmd string) {
 	}
 }
 
+func SendMessageDirectToSPOrViaPP(pb proto.Message, cmd string) {
+	if client.SPConn != nil {
+		SendMessage(client.SPConn, pb, cmd)
+	} else {
+		SendMessage(client.PPConn, pb, cmd)
+	}
+}
+
 // SendMessageToSPServer SendMessageToSPServer
 func SendMessageToSPServer(pb proto.Message, cmd string) {
 	_, err := ConnectToSP()

--- a/pp/peers/sp_peers.go
+++ b/pp/peers/sp_peers.go
@@ -71,6 +71,15 @@ func TransferSendMessageToPPServ(addr string, msgBuf *msg.RelayMsgBuf) {
 	}
 }
 
+func TransferSendMessageToPPServByP2pAddress(p2pAddress string, msgBuf *msg.RelayMsgBuf) {
+	ppInfo := setting.GetPPByP2pAddress(p2pAddress)
+	if ppInfo == nil {
+		utils.ErrorLogf("PP %v missing from local ppList. Cannot transfer message due to missing network address")
+		return
+	}
+	TransferSendMessageToPPServ(ppInfo.NetworkAddress, msgBuf)
+}
+
 // transferSendMessageToSPServer
 func TransferSendMessageToSPServer(msg *msg.RelayMsgBuf) {
 	_, err := ConnectToSP()

--- a/pp/setting/ppinfo.go
+++ b/pp/setting/ppinfo.go
@@ -12,97 +12,102 @@ import (
 	"github.com/stratosnet/sds/utils/types"
 )
 
-// IsPP
 var IsPP = false
 
-// IsLoginToSP
 var IsLoginToSP = false
 
-// State
 var State byte = ppTypes.PP_INACTIVE
 
-// IsStartMining
 var IsStartMining = false
 
-// IsAuto
 var IsAuto = false
 
-// WalletAddress
 var WalletAddress string
 
 // WalletPublicKey Public key in uncompressed format
 var WalletPublicKey []byte
 
-// WalletPrivateKey
 var WalletPrivateKey []byte
 
-// NetworkAddress
 var NetworkAddress string
 
-//RestAddress
 var RestAddress string
 
-// P2PAddress
 var P2PAddress string
 
-// P2PPublicKey
 var P2PPublicKey []byte
 
-// P2PPrivateKey
 var P2PPrivateKey []byte
 
-// SPMap
 var SPMap = &sync.Map{}
 
-// ppList
-var ppList = make(map[string]*protos.PPBaseInfo)
+// Map of the PPs that the current node knows about
+var ppMapByNetworkAddress = &sync.Map{}
+var ppMapByP2pAddress = &sync.Map{}
 
 var rwmutex sync.RWMutex
 
-// GetLocalPPList
-func GetLocalPPList() map[string]*protos.PPBaseInfo {
-	if len(ppList) > 0 {
-		return ppList
-	}
+func GetLocalPPList() []*protos.PPBaseInfo {
+	empty := true
+	ppMapByNetworkAddress.Range(func(k, v interface{}) bool {
+		empty = false
+		return false
+	})
 
-	csvFile, err := os.OpenFile(filepath.Join(Config.PPListDir, "pp-list"), os.O_CREATE|os.O_RDWR, 0777)
-	defer csvFile.Close()
-	if err != nil {
-		utils.Log("InitPPList err", err)
-	}
-	reader := csv.NewReader(csvFile)
-	reader.FieldsPerRecord = -1
-	record, err := reader.ReadAll()
-	if err != nil {
-		utils.Log("InitPPList err", err)
-	}
-	if len(record) > 0 {
+	if empty {
+		csvFile, err := os.OpenFile(filepath.Join(Config.PPListDir, "pp-list"), os.O_CREATE|os.O_RDWR, 0777)
+		defer csvFile.Close()
+		if err != nil {
+			utils.Log("InitPPList err", err)
+		}
+		reader := csv.NewReader(csvFile)
+		reader.FieldsPerRecord = -1
+		record, err := reader.ReadAll()
+		if err != nil {
+			utils.Log("InitPPList err", err)
+		}
+
 		for _, item := range record {
 			networkID, err := types.IDFromString(item[0])
-			if err == nil {
-				pp := protos.PPBaseInfo{
-					NetworkAddress: networkID.NetworkAddress,
-					P2PAddress:     networkID.P2pAddress,
-				}
-				ppList[pp.NetworkAddress] = &pp
-			} else {
+			if err != nil {
 				utils.ErrorLog("invalid networkID in local PP list: " + item[0])
+				continue
 			}
+
+			pp := &protos.PPBaseInfo{
+				NetworkAddress: networkID.NetworkAddress,
+				P2PAddress:     networkID.P2pAddress,
+			}
+			ppMapByNetworkAddress.Store(pp.NetworkAddress, pp)
+			ppMapByP2pAddress.Store(pp.P2PAddress, pp)
 		}
-	} else {
-		utils.Log("ppList == nil")
-		return nil
 	}
+
+	var ppList []*protos.PPBaseInfo
+	ppMapByNetworkAddress.Range(func(k, v interface{}) bool {
+		pp, ok := v.(*protos.PPBaseInfo)
+		if !ok {
+			utils.ErrorLogf("Invalid PP with network address %v in local PP map)", k)
+			return true
+		}
+		ppList = append(ppList, pp)
+		return true
+	})
+
 	utils.Log("ppList == ", ppList)
 	return ppList
 }
 
-// SavePPList
 func SavePPList(target *protos.RspGetPPList) {
 	for _, info := range target.PpList {
-		if info.NetworkAddress != NetworkAddress && ppList[info.NetworkAddress] == nil {
-			utils.DebugLog("add ", info.NetworkAddress, " to ppList")
-			ppList[info.NetworkAddress] = info
+		if info.NetworkAddress == NetworkAddress {
+			continue
+		}
+
+		if _, found := ppMapByP2pAddress.Load(info.P2PAddress); !found {
+			utils.DebugLogf("adding %v (%v) to local ppList", info.P2PAddress, info.NetworkAddress)
+			ppMapByP2pAddress.Store(info.P2PAddress, info)
+			ppMapByNetworkAddress.Store(info.NetworkAddress, info)
 		}
 	}
 	savePPListLocal()
@@ -116,26 +121,82 @@ func savePPListLocal() {
 	os.Truncate(ppListPath, 0)
 	csvFile, err := os.OpenFile(ppListPath, os.O_CREATE|os.O_RDWR, 0777)
 	if err != nil {
-		utils.ErrorLog("InitPPList err", err)
+		utils.ErrorLog("savePPListLocal err", err)
 		return
 	}
 	defer csvFile.Close()
 	writer := csv.NewWriter(csvFile)
-	utils.DebugLog("ppList len", len(ppList))
-	for _, post := range ppList {
-		line := []string{types.NetworkID{P2pAddress: post.P2PAddress, NetworkAddress: post.NetworkAddress}.String()}
+
+	linesWritten := 0
+	ppMapByNetworkAddress.Range(func(k, v interface{}) bool {
+		pp, ok := v.(*protos.PPBaseInfo)
+		if !ok {
+			utils.ErrorLogf("Invalid PP with network address %v in local PP map)", k)
+			return true
+		}
+
+		line := []string{types.NetworkID{P2pAddress: pp.P2PAddress, NetworkAddress: pp.NetworkAddress}.String()}
 		err = writer.Write(line)
 		if err != nil {
-			utils.ErrorLog("csv line ", err)
+			utils.ErrorLog("error when writing local ppList to csv:", err)
+			return true
 		}
-	}
+
+		linesWritten++
+		return true
+	})
 	writer.Flush()
+	utils.DebugLogf("Saved %v PPs in local ppList", linesWritten)
 }
 
-// DeletePPList
-func DeletePPList(networkAddress string) {
-	utils.DebugLog("delete PP: ", networkAddress)
-	delete(ppList, networkAddress)
+func GetPPByNetworkAddress(networkAddress string) *protos.PPBaseInfo {
+	value, found := ppMapByNetworkAddress.Load(networkAddress)
+	if !found {
+		return nil
+	}
+
+	pp, ok := value.(*protos.PPBaseInfo)
+	if !ok {
+		utils.ErrorLogf("Invalid PP with network address %v in local PP map)", networkAddress)
+		ppMapByNetworkAddress.Delete(networkAddress)
+		return nil
+	}
+	return pp
+}
+
+func GetPPByP2pAddress(p2pAddress string) *protos.PPBaseInfo {
+	value, found := ppMapByP2pAddress.Load(p2pAddress)
+	if !found {
+		return nil
+	}
+
+	pp, ok := value.(*protos.PPBaseInfo)
+	if !ok {
+		utils.ErrorLogf("Invalid PP with p2p address %v in local PP map)", p2pAddress)
+		ppMapByP2pAddress.Delete(p2pAddress)
+		return nil
+	}
+	return pp
+}
+
+func DeletePPListByNetworkAddress(networkAddress string) {
+	value, found := ppMapByNetworkAddress.Load(networkAddress)
+	if !found {
+		utils.DebugLogf("Cannot delete PP %v from local ppList: PP doesn't exist")
+		return
+	}
+
+	pp, ok := value.(*protos.PPBaseInfo)
+	if !ok {
+		utils.ErrorLogf("Invalid PP with network address %v in local PP map)", networkAddress)
+		ppMapByNetworkAddress.Delete(networkAddress)
+		return
+	}
+
+	utils.DebugLogf("deleting %v (%v) from local ppList", pp.P2PAddress, networkAddress)
+	ppMapByNetworkAddress.Delete(networkAddress)
+	ppMapByP2pAddress.Delete(pp.P2PAddress)
+
 	savePPListLocal()
 }
 


### PR DESCRIPTION
- Send messages to SP directly instead of through the gateway PP when SP is available
- Use TransferSendMessageToPPServ instead of TransferSendMessageToClient
- Local ppList now has a map indexed by p2pAddress and one by networkAddress, so it's easier to fetch the information of a known PP node