### PR TITLE
fix the new wallet cmd in terminal & add accounts cmd to config

### DIFF
--- a/cmd/ppd/accounts.go
+++ b/cmd/ppd/accounts.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stratosnet/sds/pp/setting"
+	"github.com/stratosnet/sds/utils"
+	"github.com/stratosnet/sds/utils/console"
+	"github.com/stratosnet/sds/utils/types"
+)
+
+const (
+	hdPathFlag   = "hd-path"
+	mnemonicFlag = "mnemonic"
+	passwordFlag = "password"
+	savePassFlag = "save-pass"
+	nicknameFlag = "nickname"
+
+	p2pPassFlag = "p2p-pass"
+)
+
+func createAccounts(cmd *cobra.Command, args []string) error {
+	p2ppass, _ := cmd.Flags().GetString(p2pPassFlag)
+
+	p2pkeyfiles := findp2pKeyFiles()
+
+	if len(p2pkeyfiles) < 1 {
+		p2pKeyAddress, err := utils.CreateP2PKey(setting.Config.AccountDir, "p2pkey", p2ppass,
+			types.DefaultP2PKeyPrefix)
+		if err != nil {
+			return errors.New("couldn't create p2pkey: " + err.Error())
+		}
+
+		p2pKeyAddressString, err := p2pKeyAddress.ToBech(types.DefaultP2PKeyPrefix)
+		if err != nil {
+			return errors.New("couldn't convert P2P key address to bech string: " + err.Error())
+		}
+		setting.SetConfig("P2PAddress", p2pKeyAddressString)
+		setting.SetConfig("P2PPassword", p2ppass)
+	}
+
+	nickname, _ := cmd.Flags().GetString(nicknameFlag)
+	if len(nickname) <= 0 {
+		nickname = "wallet"
+	}
+
+	password, _ := cmd.Flags().GetString(passwordFlag)
+	if len(password) <= 0 {
+		newPassword, err := console.Stdin.PromptPassword("Enter password: ")
+		if err != nil {
+			return errors.New("couldn't read password from input: " + err.Error())
+		}
+		password = newPassword
+	}
+
+	mnemonic, _ := cmd.Flags().GetString(mnemonicFlag)
+	if len(mnemonic) <= 0 {
+		newMnemonic, err := utils.NewMnemonic()
+		if err != nil {
+			return errors.Wrap(err, "Couldn't generate new mnemonic")
+		}
+		mnemonic = newMnemonic
+		fmt.Println("generated mnemonic is :  \n" +
+			"=======================================================================  \n" +
+			mnemonic + "\n" +
+			"======================================================================= \n")
+	}
+
+	hdPath, err := cmd.Flags().GetString(hdPathFlag)
+	if len(hdPath) <= 0 {
+		hdPath = setting.HD_PATH
+	}
+	//hrp, mnemonic, bip39Passphrase, hdPath
+	walletKeyAddress, err := utils.CreateWallet(setting.Config.AccountDir, nickname, password,
+		types.DefaultAddressPrefix, mnemonic, "", hdPath)
+	if err != nil {
+		return errors.New("couldn't create WalletAddress: " + err.Error())
+	}
+
+	walletKeyAddressString, err := walletKeyAddress.ToBech(types.DefaultAddressPrefix)
+	if err != nil {
+		return errors.New("couldn't convert wallet address to bech string: " + err.Error())
+	}
+	setting.SetConfig("WalletAddress", walletKeyAddressString)
+
+	save, _ := cmd.Flags().GetBool(savePassFlag)
+	if save {
+		setting.SetConfig("WalletPassword", password)
+	}
+	fmt.Println("save the mnemonic phase properly for future recover: \n" +
+		"=======================================================================  \n" +
+		mnemonic + "\n" +
+		"======================================================================= \n")
+
+	return nil
+}
+
+func findp2pKeyFiles() []string {
+	files, _ := ioutil.ReadDir(setting.Config.AccountDir)
+	var p2pkeyfiles []string
+	for _, file := range files {
+		fileName := file.Name()
+		if fileName[len(fileName)-5:] == ".json" && fileName[:len(types.DefaultP2PKeyPrefix)] == types.DefaultP2PKeyPrefix {
+			p2pkeyfiles = append(p2pkeyfiles, fileName)
+		}
+	}
+	return p2pkeyfiles
+}

--- a/cmd/ppd/main.go
+++ b/cmd/ppd/main.go
@@ -80,6 +80,25 @@ func getGenConfigCmd() *cobra.Command {
 		Short: "create default configuration file",
 		RunE:  genConfig,
 	}
+	cmd.AddCommand(getAccountCmd())
+	cmd.Flags().BoolP(createP2pKeyFlag, "p", false, "create p2p key with config file, need interactive input")
+	cmd.Flags().BoolP(createWalletFlag, "w", false, "create wallet with config file, need interactive input")
+	return cmd
+}
+
+func getAccountCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "accounts",
+		Short:   "create accounts for the node",
+		PreRunE: terminalPreRunE,
+		RunE:    createAccounts,
+	}
+	cmd.Flags().StringP(mnemonicFlag, "m", "", "bip39 mnemonic phrase, will generate one if not provide")
+	cmd.Flags().String(hdPathFlag, setting.HD_PATH, "hd-path for the wallet created")
+	cmd.Flags().StringP(passwordFlag, "p", "", "wallet password, if not provided, will need to input in prompt")
+	cmd.Flags().StringP(nicknameFlag, "n", "wallet", "name of wallet")
+	cmd.Flags().BoolP(savePassFlag, "s", false, "save wallet password to configuration file")
+	cmd.Flags().String(p2pPassFlag, "aaa", "p2p password, optional")
 	return cmd
 }
 

--- a/cmd/ppd/node.go
+++ b/cmd/ppd/node.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stratosnet/sds/utils"
 	"github.com/stratosnet/sds/utils/console"
 	"github.com/stratosnet/sds/utils/crypto/ed25519"
+	"github.com/stratosnet/sds/utils/types"
 )
 
 const (
@@ -82,12 +83,12 @@ func SetupP2PKey() error {
 		}
 
 		p2pKeyAddress, err := utils.CreateP2PKey(setting.Config.AccountDir, nickname, password,
-			setting.Config.P2PKeyPrefix)
+			types.DefaultP2PKeyPrefix)
 		if err != nil {
-			return errors.New("couldn't create WalletAddress: " + err.Error())
+			return errors.New("couldn't create p2p key: " + err.Error())
 		}
 
-		p2pKeyAddressString, err := p2pKeyAddress.ToBech(setting.Config.P2PKeyPrefix)
+		p2pKeyAddressString, err := p2pKeyAddress.ToBech(types.DefaultP2PKeyPrefix)
 		if err != nil {
 			return errors.New("couldn't convert P2P key address to bech string: " + err.Error())
 		}

--- a/cmd/ppd/terminal.go
+++ b/cmd/ppd/terminal.go
@@ -24,7 +24,7 @@ func run(cmd *cobra.Command, args []string, isExec bool) {
 	helpStr := "\n" +
 		"help                                       			show all the commands\n" +
 		"wallets                                    			acquire all wallet wallets' address\n" +
-		"newwallet ->password                       			create new wallet, input password in prompt\n" +
+		"newwallet <walletName> ->password                      create new wallet, input password in prompt\n" +
 		"login <walletAddress> ->password           			unlock and log in wallet, input password in prompt\n" +
 		"registerpeer                               			register peer to index node\n" +
 		"rp                                         			register peer to index node\n" +
@@ -59,8 +59,8 @@ func run(cmd *cobra.Command, args []string, isExec bool) {
 	}
 
 	newWallet := func(line string, param []string) bool {
-		if len(param) < 2 {
-			fmt.Println("Not enough arguments. Please provide the new wallet name and hdPath")
+		if len(param) < 1 {
+			fmt.Println("Not enough arguments. Please provide the new wallet name")
 			return false
 		}
 
@@ -70,10 +70,12 @@ func run(cmd *cobra.Command, args []string, isExec bool) {
 			return false
 		}
 
-		mnemonic := console.MyGetPassword("input bip39 mnemonic (leave blank to generate a new one)", false)
-
-		serv.CreateWallet(password, param[0], mnemonic, "", param[1])
-		return callRpc(c, "newWallet", []string{password, param[0], mnemonic, "", param[1]})
+		mnemonic, err := console.Stdin.PromptPassword("input bip39 mnemonic (leave blank to generate a new one)")
+		if err != nil {
+			fmt.Println("failed to get input mnemonic words")
+			return false
+		}
+		return callRpc(c, "newWallet", []string{password, param[0], mnemonic, setting.HD_PATH})
 	}
 
 	login := func(line string, param []string) bool {

--- a/example/network/node1/configs/config.yaml
+++ b/example/network/node1/configs/config.yaml
@@ -21,9 +21,6 @@ IsLimitDownloadSpeed: false
 LimitDownloadSpeed: 100
 IsLimitUploadSpeed: false
 LimitUploadSpeed: 100
-IsCheckFileOperation: false
-IsCheckFileTransferFinished: false
-P2PKeyPrefix: stsdsp2p
 ChainId: test-chain
 Token: ustos
 StratosChainUrl: http://127.0.0.1:1317

--- a/example/network/node2/configs/config.yaml
+++ b/example/network/node2/configs/config.yaml
@@ -21,8 +21,6 @@ IsLimitDownloadSpeed: false
 LimitDownloadSpeed: 100
 IsLimitUploadSpeed: false
 LimitUploadSpeed: 100
-IsCheckFileOperation: false
-IsCheckFileTransferFinished: false
 ChainId: test-chain
 Token: ustos
 StratosChainUrl: http://127.0.0.1:1317

--- a/example/network/node3/configs/config.yaml
+++ b/example/network/node3/configs/config.yaml
@@ -21,15 +21,13 @@ IsLimitDownloadSpeed: false
 LimitDownloadSpeed: 100
 IsLimitUploadSpeed: false
 LimitUploadSpeed: 100
-IsCheckFileOperation: false
-IsCheckFileTransferFinished: false
-P2PKeyPrefix: stsdsp2p
 ChainId: test-chain
 Token: ustos
 StratosChainUrl: http://127.0.0.1:1317
 StreamingCache: false
 RestPort: "18093"
 InternalPort: ""
+TrafficLogInterval: 10
 SPList:
 - P2PAddress: stsdsp2p1cw8qhgsxddak8hh8gs7veqmy5ku8f8za57guzj
   P2PPublicKey: stsdsp2p1zcjduepqjmfc8j7ve0jg3jwq9wkefpa34fg9hhrp7nu6rkf6hff7ml769f6q240avl

--- a/example/network/node4/configs/config.yaml
+++ b/example/network/node4/configs/config.yaml
@@ -21,15 +21,13 @@ IsLimitDownloadSpeed: false
 LimitDownloadSpeed: 100
 IsLimitUploadSpeed: false
 LimitUploadSpeed: 100
-IsCheckFileOperation: false
-IsCheckFileTransferFinished: false
-P2PKeyPrefix: stsdsp2p
 ChainId: test-chain
 Token: ustos
 StratosChainUrl: http://127.0.0.1:1317
 StreamingCache: false
 RestPort: "18094"
 InternalPort: ""
+TrafficLogInterval: 10
 SPList:
 - P2PAddress: stsdsp2p1cw8qhgsxddak8hh8gs7veqmy5ku8f8za57guzj
   P2PPublicKey: stsdsp2p1zcjduepqjmfc8j7ve0jg3jwq9wkefpa34fg9hhrp7nu6rkf6hff7ml769f6q240avl

--- a/pp/api/create_wallet.go
+++ b/pp/api/create_wallet.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/utils"
 	"github.com/stratosnet/sds/utils/httpserv"
+	"github.com/stratosnet/sds/utils/types"
 )
 
 // createWallet POST, params：(password，againpassword，name, mnemonic, passphrase, hdpath)
@@ -24,7 +25,6 @@ func createWallet(w http.ResponseWriter, request *http.Request) {
 	exp1 := regexp.MustCompile(`^[A-Za-z0-9]{8,16}$`)
 	name := "Wallet" + strconv.Itoa(len(files))
 	mnemonic := ""
-	passphrase := ""
 	hdPath := ""
 	if data["password"] != nil {
 		password = data["password"].(string)
@@ -47,12 +47,12 @@ func createWallet(w http.ResponseWriter, request *http.Request) {
 		w.Write(httpserv.NewJson(nil, setting.FAILCode, "mnemonic is required").ToBytes())
 		return
 	}
-	if data["passphrase"] != nil {
-		passphrase = data["passphrase"].(string)
-	} else {
-		w.Write(httpserv.NewJson(nil, setting.FAILCode, "bip39 passphrase is required").ToBytes())
-		return
-	}
+	//if data["passphrase"] != nil {
+	//	passphrase = data["passphrase"].(string)
+	//} else {
+	//	w.Write(httpserv.NewJson(nil, setting.FAILCode, "bip39 passphrase is required").ToBytes())
+	//	return
+	//}
 	if data["hdpath"] != nil {
 		hdPath = data["hdpath"].(string)
 	} else {
@@ -67,13 +67,13 @@ func createWallet(w http.ResponseWriter, request *http.Request) {
 		w.Write(httpserv.NewJson(nil, setting.FAILCode, "password doesn't match").ToBytes())
 		return
 	}
-	walletAddress, err := utils.CreateWallet(setting.Config.AccountDir, name, password, setting.Config.AddressPrefix,
-		mnemonic, passphrase, hdPath)
+	walletAddress, err := utils.CreateWallet(setting.Config.AccountDir, name, password, types.DefaultAddressPrefix,
+		mnemonic, "", hdPath)
 	if err != nil {
 		w.Write(httpserv.NewJson(nil, setting.FAILCode, "failed to create wallet").ToBytes())
 		return
 	}
-	walletAddressString, err := walletAddress.ToBech(setting.Config.AddressPrefix)
+	walletAddressString, err := walletAddress.ToBech(types.DefaultAddressPrefix)
 	if err != nil {
 		w.Write(httpserv.NewJson(nil, setting.FAILCode, "failed to convert wallet address to bech32 string").ToBytes())
 		return

--- a/pp/api/import_wallet.go
+++ b/pp/api/import_wallet.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stratosnet/sds/utils"
 	"github.com/stratosnet/sds/utils/crypto/secp256k1"
 	"github.com/stratosnet/sds/utils/httpserv"
+	"github.com/stratosnet/sds/utils/types"
 )
 
 // importWallet POST, params：(keystore , password)
@@ -42,7 +43,7 @@ func importWallet(w http.ResponseWriter, request *http.Request) {
 	}
 	setting.WalletPrivateKey = key.PrivateKey
 	setting.WalletPublicKey = secp256k1.PrivKeyToPubKey(key.PrivateKey)
-	setting.WalletAddress, err = key.Address.ToBech(setting.Config.AddressPrefix)
+	setting.WalletAddress, err = key.Address.ToBech(types.DefaultAddressPrefix)
 	if err != nil {
 		w.Write(httpserv.NewJson(nil, setting.FAILCode, "failed to convert wallet address to bech32 string").ToBytes())
 		return

--- a/pp/serv/account.go
+++ b/pp/serv/account.go
@@ -10,10 +10,11 @@ import (
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/utils"
 	"github.com/stratosnet/sds/utils/crypto/secp256k1"
+	"github.com/stratosnet/sds/utils/types"
 )
 
 // CreateWallet
-func CreateWallet(password, name, mnemonic, passphrase, hdPath string) string {
+func CreateWallet(password, name, mnemonic, hdPath string) string {
 	if mnemonic == "" {
 		newMnemonic, err := utils.NewMnemonic()
 		if err != nil {
@@ -22,13 +23,13 @@ func CreateWallet(password, name, mnemonic, passphrase, hdPath string) string {
 		}
 		mnemonic = newMnemonic
 	}
-	account, err := utils.CreateWallet(setting.Config.AccountDir, name, password, setting.Config.AddressPrefix,
-		mnemonic, passphrase, hdPath)
+	account, err := utils.CreateWallet(setting.Config.AccountDir, name, password, types.DefaultAddressPrefix,
+		mnemonic, "", hdPath)
 	if utils.CheckError(err) {
 		utils.ErrorLog("CreateWallet error", err)
 		return ""
 	}
-	setting.WalletAddress, err = account.ToBech(setting.Config.AddressPrefix)
+	setting.WalletAddress, err = account.ToBech(types.DefaultAddressPrefix)
 	if utils.CheckError(err) {
 		utils.ErrorLog("CreateWallet error", err)
 		return ""
@@ -38,9 +39,6 @@ func CreateWallet(password, name, mnemonic, passphrase, hdPath string) string {
 	}
 	getPublicKey(filepath.Join(setting.Config.AccountDir, setting.WalletAddress+".json"), password)
 	utils.Log("Create account success ,", setting.WalletAddress)
-	if setting.NetworkAddress != "" {
-		peers.InitPeer(event.RegisterEventHandle)
-	}
 	return setting.WalletAddress
 }
 
@@ -98,7 +96,7 @@ func Wallets() {
 	var wallets []string
 	for _, file := range files {
 		fileName := file.Name()
-		if fileName[len(fileName)-5:] == ".json" && fileName[:len(setting.Config.P2PKeyPrefix)] != setting.Config.P2PKeyPrefix {
+		if fileName[len(fileName)-5:] == ".json" && fileName[:len(types.DefaultP2PKeyPrefix)] != types.DefaultP2PKeyPrefix {
 			wallets = append(wallets, fileName[:len(fileName)-5])
 		}
 	}

--- a/pp/serv/terminal_cmd.go
+++ b/pp/serv/terminal_cmd.go
@@ -33,8 +33,8 @@ func (api *terminalCmd) Wallets(param []string) (CmdResult, error) {
 	return CmdResult{Msg: ""}, nil
 }
 
-func (api *terminalCmd) NewWallets(param []string) (CmdResult, error) {
-	CreateWallet(param[0], param[1], param[2], param[3], param[4])
+func (api *terminalCmd) NewWallet(param []string) (CmdResult, error) {
+	CreateWallet(param[0], param[1], param[2], param[3])
 	return CmdResult{Msg: ""}, nil
 }
 

--- a/pp/setting/setting.go
+++ b/pp/setting/setting.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stratosnet/sds/framework/client/cf"
 	"github.com/stratosnet/sds/relay/stratoschain"
 	"github.com/stratosnet/sds/utils"
-	"github.com/stratosnet/sds/utils/types"
 )
 
 // REPROTDHTIME 1 hour
@@ -80,41 +79,37 @@ type SPBaseInfo struct {
 }
 
 type config struct {
-	Version                     uint32
-	VersionShow                 string
-	DownloadPathMinLen          int
-	Port                        string       `yaml:"Port"`
-	NetworkAddress              string       `yaml:"NetworkAddress"`
-	Debug                       bool         `yaml:"Debug"`
-	PPListDir                   string       `yaml:"PPListDir"`
-	AccountDir                  string       `yaml:"AccountDir"`
-	StorehousePath              string       `yaml:"StorehousePath"`
-	DownloadPath                string       `yaml:"DownloadPath"`
-	P2PAddress                  string       `yaml:"P2PAddress"`
-	P2PPassword                 string       `yaml:"P2PPassword"`
-	WalletAddress               string       `yaml:"WalletAddress"`
-	WalletPassword              string       `yaml:"WalletPassword"`
-	AutoRun                     bool         `yaml:"AutoRun"`  // is auto login
-	Internal                    bool         `yaml:"Internal"` // is internal net
-	IsWallet                    bool         `yaml:"IsWallet"` // is wallet
-	BPURL                       string       `yaml:"BPURL"`    // bphttp
-	IsCheckDefaultPath          bool         `yaml:"IsCheckDefaultPath"`
-	IsLimitDownloadSpeed        bool         `yaml:"IsLimitDownloadSpeed"`
-	LimitDownloadSpeed          uint64       `yaml:"LimitDownloadSpeed"`
-	IsLimitUploadSpeed          bool         `yaml:"IsLimitUploadSpeed"`
-	LimitUploadSpeed            uint64       `yaml:"LimitUploadSpeed"`
-	IsCheckFileOperation        bool         `yaml:"IsCheckFileOperation"`
-	IsCheckFileTransferFinished bool         `yaml:"IsCheckFileTransferFinished"`
-	AddressPrefix               string       `yaml:"AddressPrefix"`
-	P2PKeyPrefix                string       `yaml:"P2PKeyPrefix"`
-	ChainId                     string       `yaml:"ChainId"`
-	Token                       string       `yaml:"Token"`
-	StratosChainUrl             string       `yaml:"StratosChainUrl"`
-	StreamingCache              bool         `yaml:"StreamingCache"`
-	RestPort                    string       `yaml:"RestPort"`
-	InternalPort                string       `yaml:"InternalPort"`
-	TrafficLogInterval          uint64       `yaml:"TrafficLogInterval"`
-	SPList                      []SPBaseInfo `yaml:"SPList"`
+	Version              uint32
+	VersionShow          string
+	DownloadPathMinLen   int
+	Port                 string       `yaml:"Port"`
+	NetworkAddress       string       `yaml:"NetworkAddress"`
+	Debug                bool         `yaml:"Debug"`
+	PPListDir            string       `yaml:"PPListDir"`
+	AccountDir           string       `yaml:"AccountDir"`
+	StorehousePath       string       `yaml:"StorehousePath"`
+	DownloadPath         string       `yaml:"DownloadPath"`
+	P2PAddress           string       `yaml:"P2PAddress"`
+	P2PPassword          string       `yaml:"P2PPassword"`
+	WalletAddress        string       `yaml:"WalletAddress"`
+	WalletPassword       string       `yaml:"WalletPassword"`
+	AutoRun              bool         `yaml:"AutoRun"`  // is auto login
+	Internal             bool         `yaml:"Internal"` // is internal net
+	IsWallet             bool         `yaml:"IsWallet"` // is wallet
+	BPURL                string       `yaml:"BPURL"`    // bphttp
+	IsCheckDefaultPath   bool         `yaml:"IsCheckDefaultPath"`
+	IsLimitDownloadSpeed bool         `yaml:"IsLimitDownloadSpeed"`
+	LimitDownloadSpeed   uint64       `yaml:"LimitDownloadSpeed"`
+	IsLimitUploadSpeed   bool         `yaml:"IsLimitUploadSpeed"`
+	LimitUploadSpeed     uint64       `yaml:"LimitUploadSpeed"`
+	ChainId              string       `yaml:"ChainId"`
+	Token                string       `yaml:"Token"`
+	StratosChainUrl      string       `yaml:"StratosChainUrl"`
+	StreamingCache       bool         `yaml:"StreamingCache"`
+	RestPort             string       `yaml:"RestPort"`
+	InternalPort         string       `yaml:"InternalPort"`
+	TrafficLogInterval   uint64       `yaml:"TrafficLogInterval"`
+	SPList               []SPBaseInfo `yaml:"SPList"`
 }
 
 var ostype = runtime.GOOS
@@ -256,40 +251,36 @@ func SetConfig(key, value string) bool {
 
 func defaultConfig() *config {
 	return &config{
-		Version:                     3,
-		VersionShow:                 Version,
-		DownloadPathMinLen:          0,
-		Port:                        "18081",
-		NetworkAddress:              "127.0.0.1",
-		Debug:                       false,
-		PPListDir:                   "./peers",
-		AccountDir:                  "./accounts",
-		StorehousePath:              "./storage",
-		DownloadPath:                "./download",
-		P2PAddress:                  "",
-		P2PPassword:                 "",
-		WalletAddress:               "",
-		WalletPassword:              "",
-		AutoRun:                     true,
-		Internal:                    false,
-		IsWallet:                    true,
-		BPURL:                       "",
-		IsCheckDefaultPath:          false,
-		IsLimitDownloadSpeed:        false,
-		LimitDownloadSpeed:          0,
-		IsLimitUploadSpeed:          false,
-		LimitUploadSpeed:            0,
-		IsCheckFileOperation:        false,
-		IsCheckFileTransferFinished: false,
-		AddressPrefix:               types.DefaultAddressPrefix,
-		P2PKeyPrefix:                types.DefaultP2PKeyPrefix,
-		ChainId:                     "stratos-testnet-3",
-		Token:                       "ustos",
-		StratosChainUrl:             "http://127.0.0.1:1317",
-		StreamingCache:              false,
-		RestPort:                    "",
-		InternalPort:                "",
-		SPList:                      []SPBaseInfo{{NetworkAddress: "127.0.0.1:8888"}},
+		Version:              3,
+		VersionShow:          Version,
+		DownloadPathMinLen:   0,
+		Port:                 "18081",
+		NetworkAddress:       "127.0.0.1",
+		Debug:                false,
+		PPListDir:            "./peers",
+		AccountDir:           "./accounts",
+		StorehousePath:       "./storage",
+		DownloadPath:         "./download",
+		P2PAddress:           "",
+		P2PPassword:          "",
+		WalletAddress:        "",
+		WalletPassword:       "",
+		AutoRun:              true,
+		Internal:             false,
+		IsWallet:             true,
+		BPURL:                "",
+		IsCheckDefaultPath:   false,
+		IsLimitDownloadSpeed: false,
+		LimitDownloadSpeed:   0,
+		IsLimitUploadSpeed:   false,
+		LimitUploadSpeed:     0,
+		ChainId:              "stratos-testnet-3",
+		Token:                "ustos",
+		StratosChainUrl:      "http://127.0.0.1:1317",
+		StreamingCache:       false,
+		RestPort:             "",
+		InternalPort:         "",
+		SPList:               []SPBaseInfo{{NetworkAddress: "127.0.0.1:8888"}},
 	}
 }
 

--- a/utils/console/terminal.go
+++ b/utils/console/terminal.go
@@ -163,18 +163,18 @@ func MyGetPassword(prompt string, confirmation bool) string {
 	if prompt != "" {
 		fmt.Println(prompt)
 	}
-	password, err := Mystdin.PromptPassword("Passphrase: ")
+	password, err := Mystdin.PromptPassword("password: ")
 	if err != nil {
 		cmd.Fatalf("Failed to read passphrase: %v", err)
 	}
 	if confirmation {
-		confirm, err := Mystdin.PromptPassword("Repeat passphrase: ")
+		confirm, err := Mystdin.PromptPassword("Repeat password: ")
 		if err != nil {
 			cmd.Fatalf("Failed to read passphrase confirmation: %v", err)
 		}
 		if password != confirm {
 			password = ""
-			cmd.Fatalf("Passphrases do not match")
+			cmd.Fatalf("password do not match")
 		}
 	}
 


### PR DESCRIPTION
@weichen-qsnetwork this pr includes breaking changes for your scripts on the account creation and config cmd
to create config without interactive key creation
`ppd config`
to create config with interactive key creation 
`ppd config -w -p`
 to create wallet key and p2p key
`ppd config accounts  -n wallet2 -p 123 -s` 
@hong-pang please update your document as well 