### PR TITLE
Fix - Send msg to gateway pp to query file storage info

### DIFF
--- a/pp/event/query_file_info.go
+++ b/pp/event/query_file_info.go
@@ -25,7 +25,7 @@ func GetFileStorageInfo(path, savePath, reqID string, isVideoStream bool, w http
 	if setting.CheckLogin() {
 		if CheckDownloadPath(path) {
 			utils.DebugLog("path:", path)
-			peers.SendMessageDirectToSPOrViaPP(requests.ReqFileStorageInfoData(path, savePath, reqID, isVideoStream, nil), header.ReqFileStorageInfo)
+			peers.SendMessage(client.PPConn, requests.ReqFileStorageInfoData(path, savePath, reqID, isVideoStream, nil), header.ReqFileStorageInfo)
 		} else {
 			utils.ErrorLog("please input correct download link, eg: sdm://address/fileHash|filename(optional)")
 			if w != nil {


### PR DESCRIPTION
We need to send msg to gateway pp to query file storage info to allow the gateway pp store file storage info in its cache. We'll later remove gateway pp from the whole downloading workflow