### PR TITLE
fix/relayd exits with exit code 1

### DIFF
--- a/cmd/relayd/relayd.go
+++ b/cmd/relayd/relayd.go
@@ -32,6 +32,7 @@ func main() {
 
 	multiClient := client.NewClient()
 	defer multiClient.Stop()
+	defer os.Exit(1)
 
 	err = multiClient.Start()
 	if err != nil {


### PR DESCRIPTION
Make relayd always exit with exit code 1, so that the systemd service automatically restarts it