### PR TITLE
Qb-1088 use different names to upload an existing file

### DIFF
--- a/pp/event/upload_file.go
+++ b/pp/event/upload_file.go
@@ -109,7 +109,11 @@ func RspUploadFile(ctx context.Context, _ core.WriteCloser) {
 		utils.ErrorLog("target.Result is nil")
 
 	} else if target.Result.State != protos.ResultState_RES_SUCCESS {
-		utils.Log("upload failed", target.Result.Msg)
+		if strings.Contains(target.Result.Msg, "Same file with the name") {
+			utils.Log(target.Result.Msg)
+		} else {
+			utils.Log("upload failed: ", target.Result.Msg)
+		}
 		file.ClearFileMap(target.FileHash)
 
 	} else if len(target.PpList) != 0 {


### PR DESCRIPTION
1. Added UhfInfo (including FileName and CreateTime) to replace the existing file info for the same uploaded file from different users   
2.  Change the log message when file already exist