### PR TITLE
Feat/QB-1098 change video cache file to  sds tmp file instead of os tmp

### DIFF
--- a/pp/api/stream_video.go
+++ b/pp/api/stream_video.go
@@ -301,10 +301,6 @@ func verifyStreamReqBody(req *http.Request) (*StreamReqBody, error) {
 		return nil, errors.Wrap(err, "incorrect SP P2P address")
 	}
 
-	if reqBody.RestAddress == "" {
-		return nil, errors.New("please give correct rest address to the file slice")
-	}
-
 	return &reqBody, nil
 }
 

--- a/pp/file/video.go
+++ b/pp/file/video.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/utils"
 )
 
@@ -128,7 +129,7 @@ func LoadHlsInfo(fileHash, sliceHash, savePath string) *HlsInfo {
 }
 
 func GetVideoTmpFolder(fileHash string) string {
-	return TEMP_FOLDER + "/" + fileHash
+	return filepath.Join(setting.GetRootPath(), TEMP_FOLDER, fileHash)
 }
 
 func GetDumpySliceData(fileHash string, sliceNumber uint64) []byte {


### PR DESCRIPTION
- use root path to build tmp folder for video upload
- remove the check of restAddress when caching video