### PR TITLE
feat/QB-1105 Block broadcast event handling

### DIFF
--- a/relay/types/broadcast.go
+++ b/relay/types/broadcast.go
@@ -73,6 +73,10 @@ func (u UnsignedMsgBytes) FromBytes() (UnsignedMsg, error) {
 		msg := sdstypes.MsgFileUpload{}
 		err = relay.Cdc.UnmarshalJSON(u.Msg, &msg)
 		unsignedMsg.Msg = msg
+	case "SdsPrepayTx":
+		msg := sdstypes.MsgPrepay{}
+		err = relay.Cdc.UnmarshalJSON(u.Msg, &msg)
+		unsignedMsg.Msg = msg
 	case "volume_report":
 		msg := pottypes.MsgVolumeReport{}
 		err = relay.Cdc.UnmarshalJSON(u.Msg, &msg)


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-1105

- After a block mode broadcast in relayd, directly call the event handlers
- Add a cache to avoid processing the same event twice
- Fix tx hash processing when dealing with multiple messages in one transaction
- Improve logs when relayd broadcasts txs
- Fix attributes used by slashing event handler