### PR TITLE
fix/QB-1177 Hashring GetNodeExcludedNodeIDs Fix

### DIFF
--- a/example/network/node1/configs/config.yaml
+++ b/example/network/node1/configs/config.yaml
@@ -1,7 +1,7 @@
 Version:
   AppVer: 7
   MinAppVer: 7
-  Show: v0.6.0
+  Show: v0.7.0
 downloadpathminlen: 88
 Port: "9081"
 NetworkAddress: 127.0.0.1
@@ -24,12 +24,11 @@ LimitUploadSpeed: 100
 ChainId: test-chain
 Token: ustos
 StratosChainUrl: http://127.0.0.1:1317
-StreamingCache: false
 RestPort: "18091"
 InternalPort: "9608"
 TrafficLogInterval: 10
 SPList:
-- P2PAddress:
-  P2PPublicKey:
+- P2PAddress: 
+  P2PPublicKey: 
   NetworkAddress: 0.0.0.0:8888
 

--- a/example/network/node2/configs/config.yaml
+++ b/example/network/node2/configs/config.yaml
@@ -1,7 +1,7 @@
 Version:
   AppVer: 7
   MinAppVer: 7
-  Show: v0.6.0
+  Show: v0.7.0
 downloadpathminlen: 88
 Port: "9082"
 NetworkAddress: 127.0.0.1
@@ -24,7 +24,6 @@ LimitUploadSpeed: 100
 ChainId: test-chain
 Token: ustos
 StratosChainUrl: http://127.0.0.1:1317
-StreamingCache: false
 RestPort: "18092"
 InternalPort: ""
 TrafficLogInterval: 10

--- a/example/network/node3/configs/config.yaml
+++ b/example/network/node3/configs/config.yaml
@@ -1,7 +1,7 @@
 Version:
   AppVer: 7
   MinAppVer: 7
-  Show: v0.6.0
+  Show: v0.7.0
 downloadpathminlen: 88
 Port: "9083"
 NetworkAddress: 127.0.0.1
@@ -24,12 +24,11 @@ LimitUploadSpeed: 100
 ChainId: test-chain
 Token: ustos
 StratosChainUrl: http://127.0.0.1:1317
-StreamingCache: false
 RestPort: "18093"
 InternalPort: ""
 TrafficLogInterval: 10
 SPList:
-- P2PAddress:
-  P2PPublicKey:
+- P2PAddress: 
+  P2PPublicKey: 
   NetworkAddress: 0.0.0.0:8888
 

--- a/example/network/node4/configs/config.yaml
+++ b/example/network/node4/configs/config.yaml
@@ -1,7 +1,7 @@
 Version:
   AppVer: 7
   MinAppVer: 7
-  Show: v0.6.0
+  Show: v0.7.0
 downloadpathminlen: 88
 Port: "9084"
 NetworkAddress: 127.0.0.1
@@ -24,12 +24,11 @@ LimitUploadSpeed: 100
 ChainId: test-chain
 Token: ustos
 StratosChainUrl: http://127.0.0.1:1317
-StreamingCache: false
 RestPort: "18094"
 InternalPort: ""
 TrafficLogInterval: 10
 SPList:
-- P2PAddress:
-  P2PPublicKey:
+- P2PAddress: 
+  P2PPublicKey: 
   NetworkAddress: 0.0.0.0:8888
 

--- a/utils/hashring/hashring.go
+++ b/utils/hashring/hashring.go
@@ -208,10 +208,9 @@ func (r *HashRing) GetNode(key string) (uint32, string) {
 	return r.GetNodeByIndex(keyIndex)
 }
 
-// GetNodeMissNodeID get node excluded given NodeIDs
+// GetNodeExcludedNodeIDs get node and exclude given NodeIDs. If setOffline is true, the excluded nodes will become offline.
 // @params key
-func (r *HashRing) GetNodeExcludedNodeIDs(key string, NodeIDs []string) (uint32, string) {
-
+func (r *HashRing) GetNodeExcludedNodeIDs(key string, NodeIDs []string, setOffline bool) (uint32, string) {
 	if len(NodeIDs) <= 0 {
 		return r.GetNode(key)
 	}
@@ -220,11 +219,21 @@ func (r *HashRing) GetNodeExcludedNodeIDs(key string, NodeIDs []string) (uint32,
 		return 0, ""
 	}
 
+	var temporaryOffline []string
 	for _, id := range NodeIDs {
-		r.SetOffline(id)
+		if r.IsOnline(id) {
+			temporaryOffline = append(temporaryOffline, id)
+			r.SetOffline(id)
+		}
 	}
 
 	index, id := r.GetNode(key)
+
+	if !setOffline {
+		for _, offlineId := range temporaryOffline {
+			r.SetOnline(offlineId)
+		}
+	}
 	return index, id
 
 	//tmpRing := New(r.NumberOfVirtual)

--- a/utils/hashring/hashring_test.go
+++ b/utils/hashring/hashring_test.go
@@ -1,0 +1,44 @@
+package hashring
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestGetNodeExcludedNodeIDs(t *testing.T) {
+	ring := New(10)
+
+	for i := 0; i < 5; i++ {
+		id := "ID#" + strconv.FormatInt(int64(i), 10)
+		ring.AddNode(&Node{
+			ID:   id,
+			Host: "",
+			Rest: "",
+			Data: nil,
+		})
+		ring.SetOnline(id)
+	}
+
+	if ring.NodeOkCount != 5 {
+		t.Fatalf("Wrong NodeOkCount [%v] (expected [%v])", ring.NodeOkCount, 5)
+	}
+
+	_, nodeId := ring.GetNodeExcludedNodeIDs("some key", []string{"ID#1", "ID#2", "ID#3", "ID#4"}, false)
+	expectedId := "ID#0"
+	if nodeId != expectedId {
+		t.Fatalf("Wrong node ID found [%v] (expected [%v])", nodeId, expectedId)
+	}
+
+	if ring.NodeOkCount != 5 {
+		t.Fatalf("Wrong NodeOkCount [%v] (expected [%v])", ring.NodeOkCount, 5)
+	}
+
+	_, nodeId = ring.GetNodeExcludedNodeIDs("some other key", []string{"ID#1", "ID#2", "ID#3", "ID#4"}, true)
+	if nodeId != expectedId {
+		t.Fatalf("Wrong node ID found [%v] (expected [%v])", nodeId, expectedId)
+	}
+
+	if ring.NodeOkCount != 1 {
+		t.Fatalf("Wrong NodeOkCount [%v] (expected [%v])", ring.NodeOkCount, 1)
+	}
+}

--- a/utils/hashring/weightedhashring.go
+++ b/utils/hashring/weightedhashring.go
@@ -215,9 +215,9 @@ func (r *WeightedHashRing) GetNode(key string) (uint32, string) {
 	return r.GetNodeByIndex(keyIndex)
 }
 
-// GetNodeMissNodeID get node excluded given NodeIDs
+// GetNodeExcludedNodeIDs get node and exclude given NodeIDs. If setOffline is true, the excluded nodes will become offline.
 // @params key
-func (r *WeightedHashRing) GetNodeExcludedNodeIDs(key string, NodeIDs []string) (uint32, string) {
+func (r *WeightedHashRing) GetNodeExcludedNodeIDs(key string, NodeIDs []string, setOffline bool) (uint32, string) {
 
 	if len(NodeIDs) <= 0 {
 		return r.GetNode(key)
@@ -227,11 +227,21 @@ func (r *WeightedHashRing) GetNodeExcludedNodeIDs(key string, NodeIDs []string) 
 		return 0, ""
 	}
 
+	var temporaryOffline []string
 	for _, id := range NodeIDs {
-		r.SetOffline(id)
+		if r.IsOnline(id) {
+			temporaryOffline = append(temporaryOffline, id)
+			r.SetOffline(id)
+		}
 	}
 
 	index, id := r.GetNode(key)
+
+	if !setOffline {
+		for _, offlineId := range temporaryOffline {
+			r.SetOnline(offlineId)
+		}
+	}
 	return index, id
 
 	//tmpRing := New(r.NumberOfVirtual)

--- a/utils/hashring/weightedhashring_test.go
+++ b/utils/hashring/weightedhashring_test.go
@@ -1,13 +1,13 @@
 package hashring
 
 import (
-	"github.com/bsipos/thist"
-	"github.com/google/uuid"
-	"github.com/stratosnet/sds/utils"
-	"math"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/bsipos/thist"
+	"github.com/google/uuid"
+	"github.com/stratosnet/sds/utils"
 )
 
 func TestWHRTrend(t *testing.T) {
@@ -16,9 +16,9 @@ func TestWHRTrend(t *testing.T) {
 	start := time.Now()
 	numNode := 100
 	for i := 1; i <= numNode; i++ {
-		tmpVWN := &WeightedNode{ID: "stsdsp2p1faej5w4q6hgnt0ft598dlm408g4p747ymg5jq6_" + strconv.Itoa(i), Host: "127.0.0.1:18092_" + strconv.Itoa(i), Rest: "127.0.0.1:18092_" + strconv.Itoa(i), Weight: math.Exp(float64(i))}
+		tmpVWN := &WeightedNode{ID: "stsdsp2p1faej5w4q6hgnt0ft598dlm408g4p747ymg5jq6_" + strconv.Itoa(i), Host: "127.0.0.1:18092_" + strconv.Itoa(i), Rest: "127.0.0.1:18092_" + strconv.Itoa(i), Tier: uint32(i)}
 		testRing.AddNode(tmpVWN)
-		testRing.NodeStatus[tmpVWN.ID] = true
+		testRing.NodeStatus.Store(tmpVWN.ID, true)
 	}
 	logPointA := time.Now()
 	utils.DebugLogf("it cost %v(s) for creating a weighted hashring of %v nodes with numOfCopies [1-%v]", logPointA.Sub(start).Seconds(), numNode, numNode)
@@ -54,4 +54,43 @@ func TestWHRTrend(t *testing.T) {
 		}
 	}
 	utils.DebugLog(h.Draw())
+}
+
+func TestGetNodeExcludedNodeIDsWeightedHashring(t *testing.T) {
+	ring := NewWeightedHashRing()
+
+	for i := 0; i < 5; i++ {
+		id := "ID#" + strconv.FormatInt(int64(i), 10)
+		ring.AddNode(&WeightedNode{
+			ID:   id,
+			Host: "",
+			Rest: "",
+			Tier: 1,
+			Data: nil,
+		})
+		ring.SetOnline(id)
+	}
+
+	if ring.NodeOkCount != 5 {
+		t.Fatalf("Wrong NodeOkCount [%v] (expected [%v])", ring.NodeOkCount, 5)
+	}
+
+	_, nodeId := ring.GetNodeExcludedNodeIDs("some key", []string{"ID#1", "ID#2", "ID#3", "ID#4"}, false)
+	expectedId := "ID#0"
+	if nodeId != expectedId {
+		t.Fatalf("Wrong node ID found [%v] (expected [%v])", nodeId, expectedId)
+	}
+
+	if ring.NodeOkCount != 5 {
+		t.Fatalf("Wrong NodeOkCount [%v] (expected [%v])", ring.NodeOkCount, 5)
+	}
+
+	_, nodeId = ring.GetNodeExcludedNodeIDs("some other key", []string{"ID#1", "ID#2", "ID#3", "ID#4"}, true)
+	if nodeId != expectedId {
+		t.Fatalf("Wrong node ID found [%v] (expected [%v])", nodeId, expectedId)
+	}
+
+	if ring.NodeOkCount != 1 {
+		t.Fatalf("Wrong NodeOkCount [%v] (expected [%v])", ring.NodeOkCount, 1)
+	}
 }


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-1177

- Fix hashring GetNodeExcludedNodeIDs method. There is now a param to specify if the excluded nodes should become offline or not