### PR TITLE
feat/QB-1199 RPC download file

### DIFF
--- a/example/rpcclient/Makefile
+++ b/example/rpcclient/Makefile
@@ -1,0 +1,11 @@
+
+build:
+	go build -o rpc_client main.go
+
+clean:
+	rm -rf rpc_client
+
+all: build
+
+
+.PHONY: all build clean

--- a/example/rpcclient/main.go
+++ b/example/rpcclient/main.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"crypto/sha256"
 	"net/http"
+	"github.com/spf13/cobra"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/api/rpc"
 	"github.com/stratosnet/sds/msg/protos"
@@ -20,10 +21,16 @@ import (
 	"github.com/tendermint/tendermint/libs/bech32"
 )
 
+const (
+	DEFAULT_URL = "http://127.0.0.1:8235"
+)
+
 var (
 	WalletPrivateKey []byte
 	WalletPublicKey  string
 	WalletAddress    string
+
+	Url              string
 )
 
 type jsonrpcMessage struct {
@@ -34,8 +41,45 @@ type jsonrpcMessage struct {
 	Result  json.RawMessage `json:"result,omitempty"`
 }
 
-func readWalletKeys() bool {
-	WalletAddress = "st1macvxhdy33kphmwv7kvvk28hpg0xn7nums5klu"
+func findWallet(folder string) string {
+	var files []string
+	var file string
+
+	err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			fmt.Println(err)
+			return nil
+		}
+		file = filepath.Base(path)
+
+		if m, _ := filepath.Match("st1*", file); !info.IsDir() && filepath.Ext(path) == ".json" && m {
+			// only catch the first wallet file
+			if files == nil {
+				files = append(files, file[:len(file) - len(filepath.Ext(file))])
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return ""
+	}
+
+	if files != nil {
+		return files[0]
+	}
+	return ""
+}
+
+func readWalletKeys(wallet string) bool {
+	if wallet == "" {
+		WalletAddress = findWallet("./account/")
+	} else {
+		WalletAddress = wallet
+	}
+	if WalletAddress == "" {
+		return false
+	}
+
 	keyjson, err := ioutil.ReadFile(filepath.Join("./account/", WalletAddress+".json"))
 	if utils.CheckError(err) {
 		utils.ErrorLog("getPublicKey ioutil.ReadFile", err)
@@ -60,43 +104,50 @@ func readWalletKeys() bool {
 	return true
 }
 
-func main() {
-	args := os.Args
-	if len(args[1:]) != 1 {
-		fmt.Println("usage: ", args[0], " file")
-		return
+func wrapJsonRpc(method string, param []byte) []byte {
+    // compose json-rpc request
+	request := &jsonrpcMessage {
+		Version: "2.0",
+			ID:  1,
+		 Method: method,
+		 Params: json.RawMessage(param),
+	 }
+	r, e := json.Marshal(request)
+	if e != nil {
+		utils.DebugLog("json marshal error", e)
+		return nil
 	}
+	return r
+}
 
-	// initialize log
-	utils.NewDefaultLogger("./logs/stdout.log", true, true)
-
-	ret := readWalletKeys()
-	if !ret {
-		utils.DebugLog("Failed reading key file.")
-		return
-	}
-	// size
-	info := file.GetFileInfo(args[1])
+func reqUploadMsg(fileName, hash string) []byte {
+	// file size
+	info := file.GetFileInfo(fileName)
 	if info == nil {
 		utils.DebugLog("Failed to get file information.")
-		return
+		return nil
 	}
 
-	// hash
-	hash := file.GetFileHash(args[1], "")
+	// wallet address
+	ret := readWalletKeys(WalletAddress)
+	if !ret {
+		utils.DebugLog("Failed reading key file.")
+		return nil
+	}
 
 	// signature
 	hs := sha256.Sum256([]byte(hash + WalletAddress))
 	sign, err := secp256k1.Sign(hs[:], WalletPrivateKey)
 	if err != nil {
 		utils.DebugLog("failed to sign, error:", err)
-		return
+		return nil
 	}
 	signature := sign[:len(sign)-1]
 
+	// param
 	var params = []rpc.ParamReqUploadFile{}
 	params = append(params, rpc.ParamReqUploadFile {
-		FileName      : args[1],
+		FileName      : fileName,
 		FileSize      : int(info.Size()),
 		FileHash      : hash,
 		WalletAddr    : WalletAddress,
@@ -107,27 +158,239 @@ func main() {
 	pm, e := json.Marshal(params)
 	if e != nil {
 		utils.DebugLog("failed marshal param for ReqUploadFile")
-		return
+		return nil
 	}
 
-	request := &jsonrpcMessage {
-		Version: "2.0",
-			ID:  1,
-		 Method: "user_requestUpload",
-		 Params: json.RawMessage(pm),
-	 }
+	// 
+	return wrapJsonRpc("user_requestUpload", pm)
+}
 
-	r, e := json.Marshal(&request)
+func uploadDataMsg(hash, data string) []byte {
+	var pa = []rpc.ParamUploadData{}
+	pa = append(pa, rpc.ParamUploadData {
+		FileHash      : hash,
+		Data          : data,
+	})
+	pm, e := json.Marshal(pa)
 	if e != nil {
-		utils.DebugLog("failed marshal ReqUploadFile", e)
-		return
+		utils.DebugLog("json marshal error", e)
+	}
+
+	return wrapJsonRpc("user_uploadData", pm)
+}
+
+
+// put
+func put(cmd *cobra.Command, args []string) error {
+	// args[0] is the first param, instead of the subcommand "put"
+	fileName := args[0]
+	hash := file.GetFileHash(args[0], "")
+
+    // compose request file upload params
+	r := reqUploadMsg(args[0], hash)
+	if r == nil {
+		return nil
+	}
+
+    // http request-respond
+	body := httpRequest(r)
+	if body == nil {
+		utils.DebugLog("http no response")
+		return nil
+	}
+
+	// handle: unmarshal response then unmarshal result
+	var rsp jsonrpcMessage
+	err := json.Unmarshal(body, &rsp)
+	if err != nil {
+		utils.DebugLog("unmarshal failed")
+		return nil
+	}
+
+	var res rpc.Result
+	err = json.Unmarshal(rsp.Result, &res)
+	if err != nil {
+		utils.DebugLog("unmarshal failed")
+		return nil
+	}
+
+	// Handle result:1 sending the content
+	for res.Return == rpc.UPLOAD_DATA {
+		// get the data from the file
+		so := &protos.SliceOffset {
+			SliceOffsetStart: *res.OffsetStart,
+			SliceOffsetEnd: *res.OffsetEnd,
+		}
+		rawData := file.GetFileData(fileName, so)
+		encoded := base64.StdEncoding.EncodeToString(rawData)
+		r = uploadDataMsg(hash, encoded)
+
+		body = httpRequest(r)
+		if body == nil {
+			utils.DebugLog("json marshal error")
+			return nil
+		}
+		
+		// Handle rsp
+		err = json.Unmarshal(body, &rsp)
+		if err != nil {
+			utils.DebugLog("unmarshal failed")
+			return nil
+		}
+		err = json.Unmarshal(rsp.Result, &res)
+		if err != nil {
+			utils.DebugLog("unmarshal failed")
+			return nil
+		}
+				fmt.Println("D")
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// getParams
+func reqDownloadMsg(hash string) []byte {
+	// wallet address
+	ret := readWalletKeys(WalletAddress)
+	if !ret {
+		utils.DebugLog("Failed reading key file.")
+		return nil
+	}
+
+	// param
+	var params = []rpc.ParamReqDownloadFile{}
+	params = append(params, rpc.ParamReqDownloadFile {
+		FileHash: hash,
+		WalletAddr: WalletAddress,
+	})
+
+	pm, e := json.Marshal(params)
+	if e != nil {
+		utils.DebugLog("failed marshal param for ReqUploadFile")
+		return nil
+	}
+
+	// wrap to the json-rpc message
+	return wrapJsonRpc("user_requestDownload", pm)
+}
+
+// downloadDataMsg
+func downloadDataMsg(hash string) []byte {
+	// param
+	var params = []rpc.ParamDownloadData{}
+	params = append(params, rpc.ParamDownloadData {
+		FileHash: hash,
+	})
+
+	pm, e := json.Marshal(params)
+	if e != nil {
+		utils.DebugLog("failed marshal param for ReqUploadFile")
+		return nil
+	}
+
+	// wrap to the json-rpc message
+	return wrapJsonRpc("user_downloadData", pm)
+}
+
+// downloadedFileInfoMsg
+func downloadedFileInfoMsg(fileHash string, fileSize uint64) []byte  {
+	// param
+	var params = []rpc.ParamDownloadFileInfo{}
+	params = append(params, rpc.ParamDownloadFileInfo {
+		FileHash: fileHash,
+		FileSize: fileSize,
+	})
+
+	pm, e := json.Marshal(params)
+	if e != nil {
+		utils.DebugLog("failed marshal param for ReqUploadFile")
+		return nil
+	}
+
+	// wrap to the json-rpc message
+	return wrapJsonRpc("user_downloadedFileInfo", pm)
+}
+
+// get
+func get(cmd *cobra.Command, args []string) error {
+
+	// args[0] is the fileHash
+	fileHash := args[0]
+
+	// compose "request file download" request
+	r := reqDownloadMsg(fileHash)
+	if r == nil {
+		return nil
+	}
+
+	// http request-respond
+	body := httpRequest(r)
+	if body == nil {
+		utils.DebugLog("json marshal error")
+		return nil
+	}
+
+	// Handle rsp
+	var rsp jsonrpcMessage
+	err := json.Unmarshal(body, &rsp)
+	if err != nil {
+	  return nil
+	}
+
+	var res rpc.Result
+	err = json.Unmarshal(rsp.Result, &res)
+	if err != nil {
+		utils.DebugLog("unmarshal failed")
+		return nil
+	}
+
+	var fileSize uint64 = 0
+	// Handle result:1 sending the content
+	for res.Return == rpc.DOWNLOAD_OK || res.Return == rpc.DL_OK_ASK_INFO {
+		// TODO: save the piece to the file
+
+		if res.Return == rpc.DL_OK_ASK_INFO {
+			r = downloadedFileInfoMsg(fileHash, fileSize)
+		}else {
+			start := *res.OffsetStart
+			end := *res.OffsetEnd
+			fileSize = fileSize + (end - start)
+			
+			r = downloadDataMsg(fileHash)
+		}
+
+		body := httpRequest(r)
+		if body == nil {
+			utils.DebugLog("json marshal error")
+			return nil
+		}
+
+		// Handle rsp
+		err := json.Unmarshal(body, &rsp)
+		if err != nil {
+			return nil
+		}
+
+		err = json.Unmarshal(rsp.Result, &res)
+		if err != nil {
+			utils.DebugLog("unmarshal failed")
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// httpRequest
+func httpRequest(request []byte) []byte {
+	if len(request) < 200 {
+		fmt.Println("--> ", string(request))
+	} else {
+		fmt.Println("--> ", string(request[:130]), "... \"}]}")
 	}
 
 	// http post
-	fmt.Println("--> ", string(r))
-
-	url := "http://127.0.0.1:8235"
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(r))
+	req, err := http.NewRequest("POST", Url, bytes.NewBuffer(request))
 	req.Header.Set("X-Custom-Header", "myvalue")
 	req.Header.Set("Content-Type", "application/json")
 
@@ -135,83 +398,67 @@ func main() {
 	resp, err := client.Do(req)
 	if err != nil {
 		panic(err)
+		return nil
 	}
 
 	body, _ := ioutil.ReadAll(resp.Body)
-	fmt.Println("<-- ", string(body))
-	resp.Body.Close()
-
-	// Handle rsp
-	var rsp jsonrpcMessage
-	err = json.Unmarshal(body, &rsp)
-	if err != nil {
-		return
-	}
-
-	var res rpc.Result
-	err = json.Unmarshal(rsp.Result, &res)
-	if err != nil {
-		return
-	}
-
-	// Handle result:1 sending the content
-	for res.Return == rpc.UPLOAD_DATA {
-		request.Method = "user_uploadData"
-
-		// get the data from the file
-		so := &protos.SliceOffset {
-			SliceOffsetStart: *res.OffsetStart,
-			SliceOffsetEnd: *res.OffsetEnd,
-		}
-
-		rawData := file.GetFileData(args[1], so)
-		encoded := base64.StdEncoding.EncodeToString(rawData)
-
-		var pa = []rpc.ParamUploadData{}
-		pa = append(pa, rpc.ParamUploadData {
-			FileHash      : hash,
-			Data          : encoded,
-		})
-		pm, e := json.Marshal(pa)
-		if e != nil {
-			utils.DebugLog("json marshal error", e)
-		}
-
-		request.Params = pm
-		r, e := json.Marshal(request)
-		if e != nil {
-			utils.DebugLog("json marshal error", e)
-		}
-
-		// http post again
-		if len(r) > 500 {
-			fmt.Println("--> ", string(r[:130]), "... \"}]}")
-		}
-
-		req, err = http.NewRequest("POST", url, bytes.NewBuffer(r))
-		req.Header.Set("X-Custom-Header", "myvalue")
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err = client.Do(req)
-		if err != nil {
-			panic(err)
-		}
-
-		body, _ = ioutil.ReadAll(resp.Body)
+	
+	if len(body) < 200 {
 		fmt.Println("<-- ", string(body))
-		resp.Body.Close()
-
-		// Handle rsp
-		err = json.Unmarshal(body, &rsp)
-		if err != nil {
-			return
-		}
-
-		err = json.Unmarshal(rsp.Result, &res)
-		if err != nil {
-			return
-		}
+	} else {
+		fmt.Println("<-- ", string(body[:130]), "... \"}]}")
 	}
 
-	return
+	resp.Body.Close()
+	return body
+}
+
+// rootPreRunE
+func rootPreRunE(cmd *cobra.Command, args []string) error {
+	var err error
+	Url, err = cmd.Flags().GetString("url")
+	if err != nil {
+		utils.ErrorLog("failed to get 'home' path for the node")
+		return err
+	}
+	WalletAddress, err = cmd.Flags().GetString("wallet")
+	if err != nil {
+		utils.ErrorLog("failed to get 'home' path for the node")
+		return err
+	}
+
+	return nil
+}
+
+// main
+func main() {
+	rootCmd := &cobra.Command{
+		Use:     "rpc_client",
+		Short:   "rpc client for test purpose",
+		PersistentPreRunE: rootPreRunE,
+	}
+	rootCmd.PersistentFlags().StringP("url", "u", DEFAULT_URL, "url to the RPC server, e.g. http://3.24.59.6:8235")
+	rootCmd.PersistentFlags().StringP("wallet", "w", "", "wallet address to be used (default: the first wallet in folder ./account/)")
+
+	putCmd := &cobra.Command{
+		Use:     "put",
+		Short:   "upload a file",
+		RunE:    put,
+	}
+
+	getCmd := &cobra.Command{
+		Use:     "get",
+		Short:   "download a file",
+		RunE:    get,
+	}
+
+	rootCmd.AddCommand(putCmd)
+	rootCmd.AddCommand(getCmd)
+
+	utils.NewDefaultLogger("./logs/stdout.log", true, true)
+
+	err := rootCmd.Execute()
+	if err != nil {
+		utils.ErrorLog(err)
+	}
 }

--- a/pp/file/file.go
+++ b/pp/file/file.go
@@ -19,7 +19,6 @@ var wmutex sync.RWMutex
 
 // key(fileHash) : value(file path)
 var fileMap = make(map[string]string)
-
 var infoMutex sync.Mutex
 
 // GetFileInfo
@@ -161,6 +160,12 @@ func SaveSliceData(data []byte, sliceHash string, offset uint64) bool {
 func SaveFileData(data []byte, offset int64, sliceHash, fileName, fileHash, savePath string) bool {
 
 	utils.DebugLog("sliceHash", sliceHash)
+
+	if IsFileRpcRemote(fileHash) {
+		// write to rpc
+		SaveRemoteFileData(fileHash, data, uint64(offset))
+		return true
+	}
 	wmutex.Lock()
 	if fileName == "" {
 		fileName = fileHash
@@ -244,6 +249,12 @@ func RecordDownloadCSV(target *protos.RspFileStorageInfo) {
 // CheckFileExisting
 func CheckFileExisting(fileHash, fileName, savePath, encryptionTag string) bool {
 	utils.DebugLog("CheckFileExisting: file Hash", fileHash)
+
+	// check if the target path is remote, return false for "not match"
+	if IsFileRpcRemote(fileHash) {
+		return false
+	}
+
 	filePath := ""
 	if savePath == "" {
 		filePath = filepath.Join(setting.Config.DownloadPath, fileName)
@@ -251,7 +262,7 @@ func CheckFileExisting(fileHash, fileName, savePath, encryptionTag string) bool 
 		filePath = filepath.Join(setting.Config.DownloadPath, savePath, fileName)
 	}
 	// if setting.IsWindows {
-	// 	filePath = filepath.FromSlash(filePath)
+	//	filePath = filepath.FromSlash(filePath)
 	// }
 	utils.DebugLog("filePath", filePath)
 	file, err := os.OpenFile(filePath, os.O_RDONLY, 0777)

--- a/pp/requests/requests.go
+++ b/pp/requests/requests.go
@@ -236,8 +236,22 @@ func RequestUploadFileData(paths, storagePath, reqID, ownerWalletAddress string,
 	}
 	task.UploadProgressMap.Store(fileHash, p)
 	// if isCover {
-	// 	os.Remove(path)
+	//	os.Remove(path)
 	// }
+	return req
+}
+
+func RequestDownloadFile(fileHash, walletAddr string) *protos.ReqFileStorageInfo {
+	// don't know the name nor the size of the file at this point, put empty name with "rpc:" flag, and 0 as the size
+	file.SaveRemoteFileHash(fileHash, "rpc:", 0)
+
+	// path: mesh network address
+	sdmPath := "sdm://" + walletAddr + "/" + fileHash
+
+	//
+	utils.DebugLog("path:", sdmPath)
+	// may need an UUID for reqId
+	req := ReqFileStorageInfoData(sdmPath, "", "", setting.WalletAddress, "", false, nil)
 	return req
 }
 

--- a/pp/serv/rpc.go
+++ b/pp/serv/rpc.go
@@ -207,17 +207,125 @@ func (api *rpcApi) UploadData(param rpc_api.ParamUploadData) rpc_api.Result {
 	}
 }
 
-type test struct {
-	FileName     string    `json:"filename"`
-	FileSize     int       `json:"filesize"`
-	FileHash     string    `json:"filehash"`
-	WalletAddr   string    `json:"walletaddr"`
-	WalletPubkey string    `json:"walletpubkey"`
-	Signature    string    `json:"signatur"`
+func (api *rpcApi) RequestDownload(param rpc_api.ParamReqDownloadFile) rpc_api.Result {
+
+	fileHash := param.FileHash
+	wallet := param.WalletAddr
+	// request for downloading file
+	req := requests.RequestDownloadFile(fileHash, wallet)
+	peers.SendMessageDirectToSPOrViaPP(req, header.ReqFileStorageInfo)
+
+	// wait for the result
+	var event = make(chan bool)
+	var result rpc_api.Result
+	var found bool
+	go func() {
+		for {
+			result, found = file.GetRemoteFileEvent(fileHash)
+			if found {
+				event <- true
+				break
+			}
+		}
+	}()
+
+	select {
+	case <-time.After(WAIT_TIMEOUT * time.Second):
+		// end of the session
+		file.CleanFileHash(fileHash)
+		return rpc_api.Result{Return: rpc_api.TIME_OUT}
+	case <-event:
+	}
+
+	//
+	if result.Return == rpc_api.DOWNLOAD_OK {
+		rawData := file.GetDownloadFileData(fileHash)
+		encoded := b64.StdEncoding.EncodeToString(rawData)
+		result.FileData = encoded
+	} else {
+		// end of the session
+		file.CleanFileHash(fileHash)
+	}
+
+	return result
 }
 
-func (api *rpcApi) Test(t test) []string {
+func (api *rpcApi) DownloadData(param rpc_api.ParamDownloadData) rpc_api.Result {
+	fileHash := param.FileHash
 
-	utils.DebugLog("hello, the world", t.FileName, t.FileHash, t.WalletAddr)
-	return []string{"0"}
+	// last piece was done, tell the called of driver to move on
+	file.SetDownloadSliceDone(fileHash)
+
+	// wait for result: DOWNLOAD_OK or DL_OK_ASK_INFO
+	var event = make(chan bool)
+	var result rpc_api.Result
+	var found bool
+
+	go func() {
+		for {
+			result, found = file.GetRemoteFileEvent(fileHash)
+			if found {
+				event <- true
+				break
+			}
+		}
+	}()
+
+	// wait too long, failure of timeout
+	select {
+	case <-time.After(WAIT_TIMEOUT * time.Second):
+		// end of the session
+		file.CleanFileHash(fileHash)
+		return rpc_api.Result{Return: rpc_api.TIME_OUT}
+	case <-event:
+	}
+
+
+	if result.Return == rpc_api.DOWNLOAD_OK {
+		rawData := file.GetDownloadFileData(fileHash)
+		encoded := b64.StdEncoding.EncodeToString(rawData)
+		result.FileData = encoded
+	}else if result.Return == rpc_api.DL_OK_ASK_INFO {
+		// finished download, and ask the file info to verify downloaded file
+	}else {
+		// end of the session
+		file.CleanFileHash(fileHash)
+	}
+
+	return result
+
+}
+
+func (api *rpcApi) DownloadedFileInfo(param rpc_api.ParamDownloadFileInfo) rpc_api.Result {
+
+	fileHash := param.FileHash
+	fileSize := param.FileSize
+	// no matter what reason, this is the end of the session, clean everything related to tthe session
+	defer file.CleanFileHash(fileHash)
+
+	file.SetRemoteFileInfo(fileHash, fileSize)
+
+	// wait for result, SUCCESS or some failure
+	var result rpc_api.Result
+	var found bool
+	var event = make(chan bool)
+
+	go func() {
+		for {
+			result, found = file.GetRemoteFileEvent(fileHash)
+			if found {
+				event <- true
+				break
+			}
+		}
+	}()
+
+	// wait too long, failure of timeout
+	select {
+	case <-time.After(WAIT_TIMEOUT * time.Second):
+		return rpc_api.Result{Return: rpc_api.TIME_OUT}
+	case <-event:
+	}
+
+	return result
 }

--- a/pp/task/download_task.go
+++ b/pp/task/download_task.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/setting"
+	"github.com/stratosnet/sds/pp/api/rpc"
 	"github.com/stratosnet/sds/utils"
 )
 
@@ -328,16 +329,23 @@ func DoneDownload(fileHash, fileName, savePath string) {
 // CheckFileOver check finished
 func CheckFileOver(fileHash, filePath string) bool {
 	utils.DebugLog("CheckFileOver")
+
 	if s, ok := DownloadSpeedOfProgress.Load(fileHash); ok {
 		sp := s.(*DownloadSP)
-		info := file.GetFileInfo(filePath)
-		if info == nil {
-			return false
+		var size int64
+		if file.IsFileRpcRemote(fileHash) {
+			size = int64(file.GetRemoteFileInfo(fileHash))
+		} else {
+			info := file.GetFileInfo(filePath)
+			if info == nil {
+				return false
+			}
+			utils.DebugLog("info", info.Size())
+			utils.DebugLog("sp.RawSize", sp.RawSize)
+			size = info.Size()
 		}
-		utils.DebugLog("info", info.Size())
-		utils.DebugLog("sp.RawSize", sp.RawSize)
 		// TODO calculate fileHash to check if download is finished
-		if info.Size() == sp.RawSize {
+		if size == sp.RawSize {
 			utils.DebugLog("ok!")
 			return true
 		}
@@ -362,6 +370,9 @@ func CheckDownloadOver(fileHash string) (bool, float32) {
 				if CheckFileOver(fileHash, filePath) {
 					DoneDownload(fileHash, fName, fInfo.SavePath)
 					CleanDownloadFileAndConnMap(fileHash)
+					if file.IsFileRpcRemote(fileHash) {
+						file.SetRemoteFileResult(fileHash, rpc.Result{Return:rpc.SUCCESS})
+					}
 					return true, 1.0
 				}
 				reCount = 5


### PR DESCRIPTION
This PR is on top of PR #188 (feat/QB-1198 RPC service and uploading file through RPC). The first commit (d925be21707750ad6fa4ee0f870459815e9d73fc) is from #188. When #188 is merged, this branch will be rebased.

*  extend the RPC server to handle download related messages
*  extend file_rpc to support download related file operations in case of remote file
*  final check in download task after download finishes
* enhance the sample client to support both upload(put) and download(get)

In this PR, parallel remote download is not supported which is in QB-1228. 
