### PR TITLE
feat/QB-1228 parallel download for RPC

### DIFF
--- a/example/rpcclient/Makefile
+++ b/example/rpcclient/Makefile
@@ -1,0 +1,11 @@
+
+build:
+	go build -o rpc_client main.go
+
+clean:
+	rm -rf rpc_client
+
+all: build
+
+
+.PHONY: all build clean

--- a/example/rpcclient/main.go
+++ b/example/rpcclient/main.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"crypto/sha256"
 	"net/http"
+	"strconv"
+	"github.com/spf13/cobra"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/api/rpc"
 	"github.com/stratosnet/sds/msg/protos"
@@ -20,10 +22,16 @@ import (
 	"github.com/tendermint/tendermint/libs/bech32"
 )
 
+const (
+	DEFAULT_URL = "http://127.0.0.1:8235"
+)
+
 var (
 	WalletPrivateKey []byte
 	WalletPublicKey  string
 	WalletAddress    string
+
+	Url              string
 )
 
 type jsonrpcMessage struct {
@@ -34,8 +42,45 @@ type jsonrpcMessage struct {
 	Result  json.RawMessage `json:"result,omitempty"`
 }
 
-func readWalletKeys() bool {
-	WalletAddress = "st1macvxhdy33kphmwv7kvvk28hpg0xn7nums5klu"
+func findWallet(folder string) string {
+	var files []string
+	var file string
+
+	err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			fmt.Println(err)
+			return nil
+		}
+		file = filepath.Base(path)
+
+		if m, _ := filepath.Match("st1*", file); !info.IsDir() && filepath.Ext(path) == ".json" && m {
+			// only catch the first wallet file
+			if files == nil {
+				files = append(files, file[:len(file) - len(filepath.Ext(file))])
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return ""
+	}
+
+	if files != nil {
+		return files[0]
+	}
+	return ""
+}
+
+func readWalletKeys(wallet string) bool {
+	if wallet == "" {
+		WalletAddress = findWallet("./account/")
+	} else {
+		WalletAddress = wallet
+	}
+	if WalletAddress == "" {
+		return false
+	}
+
 	keyjson, err := ioutil.ReadFile(filepath.Join("./account/", WalletAddress+".json"))
 	if utils.CheckError(err) {
 		utils.ErrorLog("getPublicKey ioutil.ReadFile", err)
@@ -60,43 +105,50 @@ func readWalletKeys() bool {
 	return true
 }
 
-func main() {
-	args := os.Args
-	if len(args[1:]) != 1 {
-		fmt.Println("usage: ", args[0], " file")
-		return
+func wrapJsonRpc(method string, param []byte) []byte {
+    // compose json-rpc request
+	request := &jsonrpcMessage {
+		Version: "2.0",
+			ID:  1,
+		 Method: method,
+		 Params: json.RawMessage(param),
+	 }
+	r, e := json.Marshal(request)
+	if e != nil {
+		utils.DebugLog("json marshal error", e)
+		return nil
 	}
+	return r
+}
 
-	// initialize log
-	utils.NewDefaultLogger("./logs/stdout.log", true, true)
-
-	ret := readWalletKeys()
-	if !ret {
-		utils.DebugLog("Failed reading key file.")
-		return
-	}
-	// size
-	info := file.GetFileInfo(args[1])
+func reqUploadMsg(fileName, hash string) []byte {
+	// file size
+	info := file.GetFileInfo(fileName)
 	if info == nil {
 		utils.DebugLog("Failed to get file information.")
-		return
+		return nil
 	}
 
-	// hash
-	hash := file.GetFileHash(args[1], "")
+	// wallet address
+	ret := readWalletKeys(WalletAddress)
+	if !ret {
+		utils.DebugLog("Failed reading key file.")
+		return nil
+	}
 
 	// signature
 	hs := sha256.Sum256([]byte(hash + WalletAddress))
 	sign, err := secp256k1.Sign(hs[:], WalletPrivateKey)
 	if err != nil {
 		utils.DebugLog("failed to sign, error:", err)
-		return
+		return nil
 	}
 	signature := sign[:len(sign)-1]
 
+	// param
 	var params = []rpc.ParamReqUploadFile{}
 	params = append(params, rpc.ParamReqUploadFile {
-		FileName      : args[1],
+		FileName      : fileName,
 		FileSize      : int(info.Size()),
 		FileHash      : hash,
 		WalletAddr    : WalletAddress,
@@ -107,27 +159,249 @@ func main() {
 	pm, e := json.Marshal(params)
 	if e != nil {
 		utils.DebugLog("failed marshal param for ReqUploadFile")
-		return
+		return nil
 	}
 
-	request := &jsonrpcMessage {
-		Version: "2.0",
-			ID:  1,
-		 Method: "user_requestUpload",
-		 Params: json.RawMessage(pm),
-	 }
+	// 
+	return wrapJsonRpc("user_requestUpload", pm)
+}
 
-	r, e := json.Marshal(&request)
+func uploadDataMsg(hash, data string) []byte {
+	var pa = []rpc.ParamUploadData{}
+	pa = append(pa, rpc.ParamUploadData {
+		FileHash      : hash,
+		Data          : data,
+	})
+	pm, e := json.Marshal(pa)
 	if e != nil {
-		utils.DebugLog("failed marshal ReqUploadFile", e)
-		return
+		utils.DebugLog("json marshal error", e)
+	}
+
+	return wrapJsonRpc("user_uploadData", pm)
+}
+
+
+// put
+func put(cmd *cobra.Command, args []string) error {
+	// args[0] is the first param, instead of the subcommand "put"
+	fileName := args[0]
+	hash := file.GetFileHash(args[0], "")
+
+    // compose request file upload params
+	r := reqUploadMsg(args[0], hash)
+	if r == nil {
+		return nil
+	}
+
+    // http request-respond
+	body := httpRequest(r)
+	if body == nil {
+		utils.DebugLog("http no response")
+		return nil
+	}
+
+	// handle: unmarshal response then unmarshal result
+	var rsp jsonrpcMessage
+	err := json.Unmarshal(body, &rsp)
+	if err != nil {
+		utils.DebugLog("unmarshal failed")
+		return nil
+	}
+
+	var res rpc.Result
+	err = json.Unmarshal(rsp.Result, &res)
+	if err != nil {
+		utils.DebugLog("unmarshal failed")
+		return nil
+	}
+
+	// Handle result:1 sending the content
+	for res.Return == rpc.UPLOAD_DATA {
+		// get the data from the file
+		so := &protos.SliceOffset {
+			SliceOffsetStart: *res.OffsetStart,
+			SliceOffsetEnd: *res.OffsetEnd,
+		}
+		rawData := file.GetFileData(fileName, so)
+		encoded := base64.StdEncoding.EncodeToString(rawData)
+		r = uploadDataMsg(hash, encoded)
+
+		body = httpRequest(r)
+		if body == nil {
+			utils.DebugLog("json marshal error")
+			return nil
+		}
+		
+		// Handle rsp
+		err = json.Unmarshal(body, &rsp)
+		if err != nil {
+			utils.DebugLog("unmarshal failed")
+			return nil
+		}
+		err = json.Unmarshal(rsp.Result, &res)
+		if err != nil {
+			utils.DebugLog("unmarshal failed")
+			return nil
+		}
+				fmt.Println("D")
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// getParams
+func reqDownloadMsg(hash string) []byte {
+	// wallet address
+	ret := readWalletKeys(WalletAddress)
+	if !ret {
+		utils.DebugLog("Failed reading key file.")
+		return nil
+	}
+
+	// param
+	var params = []rpc.ParamReqDownloadFile{}
+	params = append(params, rpc.ParamReqDownloadFile {
+		FileHash: hash,
+		WalletAddr: WalletAddress,
+	})
+
+	pm, e := json.Marshal(params)
+	if e != nil {
+		utils.DebugLog("failed marshal param for ReqUploadFile")
+		return nil
+	}
+
+	// wrap to the json-rpc message
+	return wrapJsonRpc("user_requestDownload", pm)
+}
+
+// downloadDataMsg
+func downloadDataMsg(hash, reqid string) []byte {
+	// param
+	var params = []rpc.ParamDownloadData{}
+	params = append(params, rpc.ParamDownloadData {
+		FileHash: hash,
+		ReqId: reqid,
+	})
+
+	pm, e := json.Marshal(params)
+	if e != nil {
+		utils.DebugLog("failed marshal param for ReqUploadFile")
+		return nil
+	}
+
+	// wrap to the json-rpc message
+	return wrapJsonRpc("user_downloadData", pm)
+}
+
+// downloadedFileInfoMsg
+func downloadedFileInfoMsg(fileHash string, fileSize uint64, reqid string) []byte  {
+	// param
+	var params = []rpc.ParamDownloadFileInfo{}
+	params = append(params, rpc.ParamDownloadFileInfo {
+		FileHash: fileHash,
+		FileSize: fileSize,
+		ReqId: reqid,
+	})
+
+	pm, e := json.Marshal(params)
+	if e != nil {
+		utils.DebugLog("failed marshal param for ReqUploadFile")
+		return nil
+	}
+
+	// wrap to the json-rpc message
+	return wrapJsonRpc("user_downloadedFileInfo", pm)
+}
+
+// get
+func get(cmd *cobra.Command, args []string) error {
+
+	// args[0] is the fileHash
+	fileHash := args[0]
+
+	// compose "request file download" request
+	r := reqDownloadMsg(fileHash)
+	if r == nil {
+		return nil
+	}
+
+	// http request-respond
+	body := httpRequest(r)
+	if body == nil {
+		utils.DebugLog("json marshal error")
+		return nil
+	}
+
+	// Handle rsp
+	var rsp jsonrpcMessage
+	err := json.Unmarshal(body, &rsp)
+	if err != nil {
+	  return nil
+	}
+
+	var res rpc.Result
+	err = json.Unmarshal(rsp.Result, &res)
+	if err != nil {
+		utils.DebugLog("unmarshal failed")
+		return nil
+	}
+
+	var fileSize uint64 = 0
+	var pieceCount uint64 = 0
+	// Handle result:1 sending the content
+	for res.Return == rpc.DOWNLOAD_OK || res.Return == rpc.DL_OK_ASK_INFO {
+		// TODO: save the piece to the file
+		if res.Return == rpc.DL_OK_ASK_INFO {
+			r = downloadedFileInfoMsg(fileHash, fileSize, res.ReqId)
+			fmt.Println("There are", pieceCount, "pieces received.")
+		}else {
+			start := *res.OffsetStart
+			end := *res.OffsetEnd
+			fileSize = fileSize + (end - start)
+			decoded, _ := base64.StdEncoding.DecodeString(res.FileData)
+			if len(decoded) != int(end - start) {
+				utils.DebugLog("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+				utils.DebugLog("Wrong size:", strconv.Itoa(len(decoded)), " ", strconv.Itoa(int(end-start)))
+				return nil
+			}
+			pieceCount = pieceCount + 1
+			r = downloadDataMsg(fileHash, res.ReqId)
+		}
+
+		body := httpRequest(r)
+		if body == nil {
+			utils.DebugLog("json marshal error")
+			return nil
+		}
+
+		// Handle rsp
+		err := json.Unmarshal(body, &rsp)
+		if err != nil {
+			return nil
+		}
+
+		err = json.Unmarshal(rsp.Result, &res)
+		if err != nil {
+			utils.DebugLog("unmarshal failed")
+			return nil
+		}
+	}
+
+	return nil
+
+}
+
+// httpRequest
+func httpRequest(request []byte) []byte {
+	if len(request) < 200 {
+		fmt.Println("--> ", string(request))
+	} else {
+		fmt.Println("--> ", string(request[:130]), "... \"}]}")
 	}
 
 	// http post
-	fmt.Println("--> ", string(r))
-
-	url := "http://127.0.0.1:8235"
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(r))
+	req, err := http.NewRequest("POST", Url, bytes.NewBuffer(request))
 	req.Header.Set("X-Custom-Header", "myvalue")
 	req.Header.Set("Content-Type", "application/json")
 
@@ -135,83 +409,66 @@ func main() {
 	resp, err := client.Do(req)
 	if err != nil {
 		panic(err)
+		return nil
 	}
 
 	body, _ := ioutil.ReadAll(resp.Body)
-	fmt.Println("<-- ", string(body))
-	resp.Body.Close()
-
-	// Handle rsp
-	var rsp jsonrpcMessage
-	err = json.Unmarshal(body, &rsp)
-	if err != nil {
-		return
-	}
-
-	var res rpc.Result
-	err = json.Unmarshal(rsp.Result, &res)
-	if err != nil {
-		return
-	}
-
-	// Handle result:1 sending the content
-	for res.Return == rpc.UPLOAD_DATA {
-		request.Method = "user_uploadData"
-
-		// get the data from the file
-		so := &protos.SliceOffset {
-			SliceOffsetStart: *res.OffsetStart,
-			SliceOffsetEnd: *res.OffsetEnd,
-		}
-
-		rawData := file.GetFileData(args[1], so)
-		encoded := base64.StdEncoding.EncodeToString(rawData)
-
-		var pa = []rpc.ParamUploadData{}
-		pa = append(pa, rpc.ParamUploadData {
-			FileHash      : hash,
-			Data          : encoded,
-		})
-		pm, e := json.Marshal(pa)
-		if e != nil {
-			utils.DebugLog("json marshal error", e)
-		}
-
-		request.Params = pm
-		r, e := json.Marshal(request)
-		if e != nil {
-			utils.DebugLog("json marshal error", e)
-		}
-
-		// http post again
-		if len(r) > 500 {
-			fmt.Println("--> ", string(r[:130]), "... \"}]}")
-		}
-
-		req, err = http.NewRequest("POST", url, bytes.NewBuffer(r))
-		req.Header.Set("X-Custom-Header", "myvalue")
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err = client.Do(req)
-		if err != nil {
-			panic(err)
-		}
-
-		body, _ = ioutil.ReadAll(resp.Body)
+	if len(body) < 200 {
 		fmt.Println("<-- ", string(body))
-		resp.Body.Close()
-
-		// Handle rsp
-		err = json.Unmarshal(body, &rsp)
-		if err != nil {
-			return
-		}
-
-		err = json.Unmarshal(rsp.Result, &res)
-		if err != nil {
-			return
-		}
+	} else {
+		fmt.Println("<-- ", string(body[:130]), "... \"}]}")
 	}
 
-	return
+	resp.Body.Close()
+	return body
+}
+
+// rootPreRunE
+func rootPreRunE(cmd *cobra.Command, args []string) error {
+	var err error
+	Url, err = cmd.Flags().GetString("url")
+	if err != nil {
+		utils.ErrorLog("failed to get 'home' path for the node")
+		return err
+	}
+	WalletAddress, err = cmd.Flags().GetString("wallet")
+	if err != nil {
+		utils.ErrorLog("failed to get 'home' path for the node")
+		return err
+	}
+
+	return nil
+}
+
+// main
+func main() {
+	rootCmd := &cobra.Command{
+		Use:     "rpc_client",
+		Short:   "rpc client for test purpose",
+		PersistentPreRunE: rootPreRunE,
+	}
+	rootCmd.PersistentFlags().StringP("url", "u", DEFAULT_URL, "url to the RPC server, e.g. http://3.24.59.6:8235")
+	rootCmd.PersistentFlags().StringP("wallet", "w", "", "wallet address to be used (default: the first wallet in folder ./account/)")
+
+	putCmd := &cobra.Command{
+		Use:     "put",
+		Short:   "upload a file",
+		RunE:    put,
+	}
+
+	getCmd := &cobra.Command{
+		Use:     "get",
+		Short:   "download a file",
+		RunE:    get,
+	}
+
+	rootCmd.AddCommand(putCmd)
+	rootCmd.AddCommand(getCmd)
+
+	utils.NewDefaultLogger("./logs/stdout.log", true, true)
+
+	err := rootCmd.Execute()
+	if err != nil {
+		utils.ErrorLog(err)
+	}
 }

--- a/framework/client/cf/conn.go
+++ b/framework/client/cf/conn.go
@@ -168,8 +168,9 @@ func Mylog(b bool, v ...interface{}) {
 // client
 func newClientConnWithOptions(netid int64, c net.Conn, opts options) *ClientConn {
 	if opts.bufferSize == 0 {
-		opts.bufferSize = 100
+		opts.bufferSize = 200
 	}
+
 	cc := &ClientConn{
 		addr:             c.RemoteAddr().String(),
 		opts:             opts,

--- a/pp/api/rpc/rpc_api.go
+++ b/pp/api/rpc/rpc_api.go
@@ -1,0 +1,64 @@
+package rpc
+
+
+const (
+	
+	SIGNATURE_FAILURE     string = "-3"
+	WRONG_FILE_SIZE       string = "-4"
+	TIME_OUT              string = "-5"
+	FILE_REQ_FAILURE      string = "-6"
+	WRONG_INPUT           string = "-7"
+	WRONG_PP_ADDRESS      string = "-8"
+	INTERNAL_DATA_FAILURE string = "-9"
+	INTERNAL_COMM_FAILURE string = "-10"
+
+	UPLOAD_DATA           string = "1"
+	DOWNLOAD_OK           string = "2"
+	DL_OK_ASK_INFO        string = "3"
+	SUCCESS               string = "0"
+)
+
+// upload: request upload file
+type ParamReqUploadFile struct {
+	FileName      string    `json:"filename"`
+	FileSize      int       `json:"filesize"`
+	FileHash      string    `json:"filehash"`
+	WalletAddr    string    `json:"walletaddr"`
+	WalletPubkey  string    `json:"walletpubkey"`
+	Signature     string    `json:"signature"`
+}
+
+// upload: upload file data
+type ParamUploadData struct {
+	FileHash      string   `json:"filehash"`
+	Data          string   `json:"data"`
+}
+
+// download: request download file
+type ParamReqDownloadFile struct {
+	FileHash      string   `json:"filehash"`
+	WalletAddr    string   `json:"walletaddr"`
+}
+
+// download: download file data
+type ParamDownloadData struct {
+	FileHash      string   `json:"filehash"`
+	ReqId         string   `json:"reqid"`
+}
+
+// download: downloaded file info
+type ParamDownloadFileInfo struct {
+	FileHash      string   `json:"filehash"`
+	FileSize      uint64   `json:"filesize"`
+	ReqId         string   `json:"reqid"`
+}
+
+// result for all upload and download messages
+type Result struct {
+	Return        string     `json:"return"`
+	ReqId         string     `json:"reqid,omitempty"`
+	OffsetStart   *uint64    `json:"offsetstart,omitempty"`
+	OffsetEnd     *uint64    `json:"offsetend,omitempty"`
+	FileData      string     `json:"filedata,omitempty"`
+}
+

--- a/pp/api/stream_video.go
+++ b/pp/api/stream_video.go
@@ -66,7 +66,7 @@ func streamVideoInfoCache(w http.ResponseWriter, req *http.Request) {
 	}
 
 	task.VideoCacheTaskMap.Delete(fileHash)
-	task.DownloadFileMap.Delete(fileHash)
+	task.DownloadFileMap.Delete(fileHash + task.LOCAL_REQID)
 	streamInfo, err := getStreamInfo(fileHash, ownerWalletAddress, setting.WalletAddress, w)
 	if err != nil {
 		w.WriteHeader(setting.FAILCode)
@@ -85,7 +85,7 @@ func streamVideoInfoHttp(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	task.DownloadFileMap.Delete(fileHash)
+	task.DownloadFileMap.Delete(fileHash + task.LOCAL_REQID)
 	streamInfo, err := getStreamInfo(fileHash, ownerWalletAddress, setting.WalletAddress, w)
 	if err != nil {
 		w.WriteHeader(setting.FAILCode)
@@ -144,7 +144,7 @@ func streamVideoHttp(w http.ResponseWriter, req *http.Request) {
 
 func redirectToResourceNode(fileHash, sliceHash, restAddress, walletAddress string, w http.ResponseWriter, req *http.Request) {
 	var targetAddress string
-	if dlTask, ok := task.DownloadTaskMap.Load(fileHash + walletAddress); ok {
+	if dlTask, ok := task.DownloadTaskMap.Load(fileHash + walletAddress + task.LOCAL_REQID); ok {
 		//self is the resource PP and has task info
 		downloadTask := dlTask.(*task.DownloadTask)
 		targetAddress = downloadTask.SliceInfo[sliceHash].StoragePpInfo.RestAddress
@@ -158,7 +158,7 @@ func redirectToResourceNode(fileHash, sliceHash, restAddress, walletAddress stri
 }
 
 func clearStreamTask(w http.ResponseWriter, req *http.Request) {
-	event.ClearFileInfoAndDownloadTask(parseFileHash(req.URL), w)
+	event.ClearFileInfoAndDownloadTask(parseFileHash(req.URL), task.LOCAL_REQID, w)
 }
 
 func GetVideoSlice(w http.ResponseWriter, req *http.Request) {
@@ -175,7 +175,7 @@ func GetVideoSlice(w http.ResponseWriter, req *http.Request) {
 
 	utils.DebugLog("The request body is ", body)
 
-	if dlTask, ok := task.DownloadTaskMap.Load(body.FileHash + setting.WalletAddress); ok {
+	if dlTask, ok := task.DownloadTaskMap.Load(body.FileHash + setting.WalletAddress + task.LOCAL_REQID); ok {
 		utils.DebugLog("Found task info ", body)
 		downloadTask := dlTask.(*task.DownloadTask)
 		ppInfo := downloadTask.SliceInfo[sliceHash].StoragePpInfo
@@ -242,7 +242,7 @@ func getStreamInfo(fileHash, ownerWalletAddress, walletAddress string, w http.Re
 	var fInfo *protos.RspFileStorageInfo
 	start := time.Now().Unix()
 	for {
-		if f, ok := task.DownloadFileMap.Load(fileHash); ok {
+		if f, ok := task.DownloadFileMap.Load(fileHash + task.LOCAL_REQID); ok {
 			fInfo = f.(*protos.RspFileStorageInfo)
 			utils.DebugLog("Received file storage info from sp ", fInfo)
 			break

--- a/pp/event/download_slice.go
+++ b/pp/event/download_slice.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/stratosnet/sds/framework/client/cf"
 	"github.com/stratosnet/sds/framework/core"
@@ -84,7 +83,7 @@ func splitSendDownloadSliceData(rsp *protos.RspDownloadSlice, conn core.WriteClo
 			offsetEnd += setting.MAXDATA
 		} else {
 			peers.SendResponseMessageWithReqId(conn, requests.RspDownloadSliceDataSplit(rsp, dataStart, 0, offsetStart, 0,
-				rsp.SliceInfo.SliceOffset.SliceOffsetStart, rsp.SliceInfo.SliceOffset.SliceOffsetEnd, true), header.RspDownloadSlice, reqId)
+			rsp.SliceInfo.SliceOffset.SliceOffsetStart, rsp.SliceInfo.SliceOffset.SliceOffsetEnd, true), header.RspDownloadSlice, reqId)
 			return
 		}
 	}
@@ -98,7 +97,12 @@ func RspDownloadSlice(ctx context.Context, conn core.WriteCloser) {
 		return
 	}
 
-	dTask, ok := task.GetDownloadTask(target.FileHash, target.WalletAddress)
+	sid, ok := task.SliceSessionMap.Load(target.ReqId)
+	if !ok {
+		utils.DebugLog("Can't find who created slice request", target.ReqId)
+	}
+
+	dTask, ok := task.GetDownloadTask(target.FileHash, target.WalletAddress, sid.(string))
 	if !ok {
 		utils.DebugLog("current task is stopped！！！！！！！！！！！！！！！！！！！！！！！！！！")
 		return
@@ -115,7 +119,7 @@ func RspDownloadSlice(ctx context.Context, conn core.WriteCloser) {
 		return
 	}
 
-	if f, ok := task.DownloadFileMap.Load(target.FileHash); ok {
+	if f, ok := task.DownloadFileMap.Load(target.FileHash+sid.(string)); ok {
 		fInfo := f.(*protos.RspFileStorageInfo)
 		utils.DebugLog("get a slice -------")
 		utils.DebugLog("SliceHash", target.SliceInfo.SliceHash)
@@ -128,32 +132,38 @@ func RspDownloadSlice(ctx context.Context, conn core.WriteCloser) {
 			receiveSliceAndProgress(&target, fInfo, dTask)
 		}
 		if !fInfo.IsVideoStream {
-			task.DownloadProgress(target.FileHash, uint64(len(target.Data)))
+			task.DownloadProgress(target.FileHash, sid.(string), uint64(len(target.Data)))
 		}
+	} else {
+		utils.DebugLog("DownloadFileMap doesn't have entry with file hash", target.FileHash);
 	}
 }
 
 func receiveSliceAndProgress(target *protos.RspDownloadSlice, fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) {
 	if task.SaveDownloadFile(target, fInfo) {
 		dataLen := uint64(len(target.Data))
-		if s, ok := task.DownloadSliceProgress.Load(target.SliceInfo.SliceHash); ok {
+		if s, ok := task.DownloadSliceProgress.Load(target.SliceInfo.SliceHash + fInfo.ReqId); ok {
 			alreadySize := s.(uint64)
 			alreadySize += dataLen
 			if alreadySize == target.SliceSize {
 				utils.DebugLog("slice download finished", target.SliceInfo.SliceHash)
-				task.DownloadSliceProgress.Delete(target.SliceInfo.SliceHash)
+				task.DownloadSliceProgress.Delete(target.SliceInfo.SliceHash + fInfo.ReqId)
 				receivedSlice(target, fInfo, dTask)
 			} else {
-				task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash, alreadySize)
+				task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash + fInfo.ReqId, alreadySize)
 			}
 		} else {
 			// if data is sent at once
 			if target.SliceSize == dataLen {
 				receivedSlice(target, fInfo, dTask)
 			} else {
-				task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash, dataLen)
+				task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash + fInfo.ReqId, dataLen)
 			}
 		}
+	}else {
+		utils.DebugLog("Download failed: not able to write to the target file.")
+		file.CloseDownloadSession(fInfo.FileHash + fInfo.ReqId)
+		task.CleanDownloadFileAndConnMap(fInfo.FileHash, fInfo.ReqId)
 	}
 }
 
@@ -162,12 +172,12 @@ func receiveSliceAndProgressEncrypted(target *protos.RspDownloadSlice, fInfo *pr
 	dataToDecryptSize := uint64(len(dataToDecrypt))
 	encryptedOffset := target.SliceInfo.EncryptedSliceOffset
 
-	if existingSlice, ok := task.DownloadEncryptedSlices.Load(target.SliceInfo.SliceHash); ok {
+	if existingSlice, ok := task.DownloadEncryptedSlices.Load(target.SliceInfo.SliceHash + fInfo.ReqId); ok {
 		existingSliceData := existingSlice.([]byte)
 		copy(existingSliceData[encryptedOffset.SliceOffsetStart:encryptedOffset.SliceOffsetEnd], dataToDecrypt)
 		dataToDecrypt = existingSliceData
 
-		if s, ok := task.DownloadSliceProgress.Load(target.SliceInfo.SliceHash); ok {
+		if s, ok := task.DownloadSliceProgress.Load(target.SliceInfo.SliceHash + fInfo.ReqId); ok {
 			existingSize := s.(uint64)
 			dataToDecryptSize += existingSize
 		}
@@ -184,8 +194,8 @@ func receiveSliceAndProgressEncrypted(target *protos.RspDownloadSlice, fInfo *pr
 
 		if task.SaveDownloadFile(target, fInfo) {
 			utils.DebugLog("slice download finished", target.SliceInfo.SliceHash)
-			task.DownloadSliceProgress.Delete(target.SliceInfo.SliceHash)
-			task.DownloadEncryptedSlices.Delete(target.SliceInfo.SliceHash)
+			task.DownloadSliceProgress.Delete(target.SliceInfo.SliceHash + fInfo.ReqId)
+			task.DownloadEncryptedSlices.Delete(target.SliceInfo.SliceHash + fInfo.ReqId)
 			receivedSlice(target, fInfo, dTask)
 		}
 	} else {
@@ -195,14 +205,14 @@ func receiveSliceAndProgressEncrypted(target *protos.RspDownloadSlice, fInfo *pr
 			dataToStore = make([]byte, target.SliceSize)
 			copy(dataToStore[encryptedOffset.SliceOffsetStart:encryptedOffset.SliceOffsetEnd], dataToDecrypt)
 		}
-		task.DownloadEncryptedSlices.Store(target.SliceInfo.SliceHash, dataToStore)
-		task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash, dataToDecryptSize)
+		task.DownloadEncryptedSlices.Store(target.SliceInfo.SliceHash + fInfo.ReqId, dataToStore)
+		task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash + fInfo.ReqId, dataToDecryptSize)
 	}
 }
 
 func receivedSlice(target *protos.RspDownloadSlice, fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) {
-	file.SaveDownloadProgress(target.SliceInfo.SliceHash, fInfo.FileName, target.FileHash, target.SavePath)
-	task.CleanDownloadTask(target.FileHash, target.SliceInfo.SliceHash, target.WalletAddress)
+	file.SaveDownloadProgress(target.SliceInfo.SliceHash, fInfo.FileName, target.FileHash, target.SavePath, fInfo.ReqId)
+	task.CleanDownloadTask(target.FileHash, target.SliceInfo.SliceHash, target.WalletAddress, fInfo.ReqId)
 	target.Result = &protos.Result{
 		State: protos.ResultState_RES_SUCCESS,
 	}
@@ -237,7 +247,8 @@ func SendReportStreamingResult(target *protos.RspDownloadSlice, isPP bool) {
 // DownloadFileSlice
 func DownloadFileSlice(target *protos.RspFileStorageInfo) {
 	fileSize := uint64(0)
-	dTask, _ := task.GetDownloadTask(target.FileHash, target.WalletAddress)
+
+	dTask, _ := task.GetDownloadTask(target.FileHash, target.WalletAddress, target.ReqId)
 	for _, sliceInfo := range target.SliceInfo {
 		fileSize += sliceInfo.SliceStorageInfo.SliceSize
 	}
@@ -248,32 +259,33 @@ func DownloadFileSlice(target *protos.RspFileStorageInfo) {
 		TotalSize:      int64(fileSize),
 		DownloadedSize: 0,
 	}
-	if !file.CheckFileExisting(target.FileHash, target.FileName, target.SavePath, target.EncryptionTag) {
-		task.DownloadSpeedOfProgress.Store(target.FileHash, sp)
+	if !file.CheckFileExisting(target.FileHash, target.FileName, target.SavePath, target.EncryptionTag, target.ReqId) {
+		task.DownloadSpeedOfProgress.Store(target.FileHash + target.ReqId, sp)
 		for _, rsp := range target.SliceInfo {
 			utils.DebugLog("taskid ======= ", rsp.TaskId)
-			if file.CheckSliceExisting(target.FileHash, target.FileName, rsp.SliceStorageInfo.SliceHash, target.SavePath) {
+			if file.CheckSliceExisting(target.FileHash, target.FileName, rsp.SliceStorageInfo.SliceHash, target.SavePath, target.ReqId) {
 				utils.Log("slice exist already,", rsp.SliceStorageInfo.SliceHash)
-				task.DownloadProgress(target.FileHash, rsp.SliceStorageInfo.SliceSize)
-				task.CleanDownloadTask(target.FileHash, rsp.SliceStorageInfo.SliceHash, target.WalletAddress)
+				task.DownloadProgress(target.FileHash, target.ReqId, rsp.SliceStorageInfo.SliceSize)
+				task.CleanDownloadTask(target.FileHash, rsp.SliceStorageInfo.SliceHash, target.WalletAddress, target.ReqId)
 				setDownloadSliceSuccess(rsp.SliceStorageInfo.SliceHash, dTask)
 			} else {
 				utils.DebugLog("request download data")
 				req := requests.ReqDownloadSliceData(target, rsp)
-				SendReqDownloadSlice(target.FileHash, rsp, req)
+				task.SliceSessionMap.Store(req.ReqId, target.ReqId)
+				SendReqDownloadSlice(target.FileHash, rsp, req, target.ReqId)
 			}
 		}
-	} else {
+  	} else {
 		utils.ErrorLog("file exists already!")
-		task.DeleteDownloadTask(target.FileHash, target.WalletAddress)
+		task.DeleteDownloadTask(target.FileHash, target.WalletAddress, target.ReqId)
 	}
 }
 
-func SendReqDownloadSlice(fileHash string, sliceInfo *protos.DownloadSliceInfo, req *protos.ReqDownloadSlice) {
+func SendReqDownloadSlice(fileHash string, sliceInfo *protos.DownloadSliceInfo, req *protos.ReqDownloadSlice, fileReqId string) {
 	utils.DebugLog("req = ", req)
-
+	
 	networkAddress := sliceInfo.StoragePpInfo.NetworkAddress
-	key := fileHash + sliceInfo.StoragePpInfo.P2PAddress
+	key := fileHash + sliceInfo.StoragePpInfo.P2PAddress + fileReqId
 
 	if c, ok := client.DownloadConnMap.Load(key); ok {
 		conn := c.(*cf.ClientConn)
@@ -296,7 +308,7 @@ func SendReqDownloadSlice(fileHash string, sliceInfo *protos.DownloadSliceInfo, 
 	conn := client.NewClient(networkAddress, false)
 	if conn == nil {
 		utils.ErrorLog("Fail to create connection with " + networkAddress)
-		if dTask, ok := task.GetDownloadTask(fileHash, req.WalletAddress); ok {
+		if dTask, ok := task.GetDownloadTask(fileHash, req.WalletAddress, fileReqId); ok {
 			setDownloadSliceFail(sliceInfo.SliceStorageInfo.SliceHash, dTask)
 		}
 		return
@@ -327,7 +339,7 @@ func RspDownloadSliceWrong(ctx context.Context, conn core.WriteCloser) {
 	if requests.UnmarshalData(ctx, &target) {
 		if target.Result.State == protos.ResultState_RES_SUCCESS {
 			utils.DebugLog("RspDownloadSliceWrongRspDownloadSliceWrongRspDownloadSliceWrong", target.NewSliceInfo.SliceStorageInfo.SliceHash)
-			if dlTask, ok := task.DownloadTaskMap.Load(target.FileHash + target.WalletAddress); ok {
+			if dlTask, ok := task.DownloadTaskMap.Load(target.FileHash + target.WalletAddress + task.LOCAL_REQID); ok {
 				downloadTask := dlTask.(*task.DownloadTask)
 				if sInfo, ok := downloadTask.SliceInfo[target.NewSliceInfo.SliceStorageInfo.SliceHash]; ok {
 					sInfo.StoragePpInfo.P2PAddress = target.NewSliceInfo.StoragePpInfo.P2PAddress
@@ -349,8 +361,8 @@ func downloadWrong(taskID, sliceHash, p2pAddress, walletAddress string, wrongTyp
 func DownloadSlicePause(fileHash, reqID string, w http.ResponseWriter) {
 	if setting.CheckLogin() {
 		// storeResponseWriter(reqID, w)
-		task.DownloadTaskMap.Delete(fileHash + setting.WalletAddress)
-		task.CleanDownloadFileAndConnMap(fileHash)
+		task.DownloadTaskMap.Delete(fileHash + setting.WalletAddress + task.LOCAL_REQID)
+		task.CleanDownloadFileAndConnMap(fileHash, reqID)
 	} else {
 		notLogin(w)
 	}
@@ -360,8 +372,8 @@ func DownloadSlicePause(fileHash, reqID string, w http.ResponseWriter) {
 func DownloadSliceCancel(fileHash, reqID string, w http.ResponseWriter) {
 	if setting.CheckLogin() {
 		storeResponseWriter(reqID, w)
-		task.DownloadTaskMap.Delete(fileHash + setting.WalletAddress)
-		task.CleanDownloadFileAndConnMap(fileHash)
+		task.DownloadTaskMap.Delete(fileHash + setting.WalletAddress + task.LOCAL_REQID)
+		task.CleanDownloadFileAndConnMap(fileHash, reqID)
 		task.CancelDownloadTask(fileHash)
 	} else {
 		notLogin(w)

--- a/pp/event/query_file_info.go
+++ b/pp/event/query_file_info.go
@@ -40,7 +40,7 @@ func GetFileStorageInfo(path, savePath, reqID, walletAddr, saveAs string, isVide
 	walletAddress := path[6:47]
 	fileHash := path[48:88]
 
-	if ok := task.CheckDownloadTask(fileHash, walletAddress); ok {
+	if ok := task.CheckDownloadTask(fileHash, walletAddress, task.LOCAL_REQID); ok {
 		msg := "The previous download task hasn't finished, please check back later"
 		utils.ErrorLog(msg)
 		if w != nil {
@@ -53,10 +53,10 @@ func GetFileStorageInfo(path, savePath, reqID, walletAddr, saveAs string, isVide
 	peers.SendMessageDirectToSPOrViaPP(req, header.ReqFileStorageInfo)
 }
 
-func ClearFileInfoAndDownloadTask(fileHash string, w http.ResponseWriter) {
+func ClearFileInfoAndDownloadTask(fileHash string, fileReqId string, w http.ResponseWriter) {
 	if setting.CheckLogin() {
-		task.DownloadFileMap.Delete(fileHash)
-		task.DeleteDownloadTask(fileHash, setting.WalletAddress)
+		task.DownloadFileMap.Delete(fileHash + fileReqId)
+		task.DeleteDownloadTask(fileHash, setting.WalletAddress, "")
 		req := &protos.ReqClearDownloadTask{
 			WalletAddress: setting.WalletAddress,
 			FileHash:      fileHash,
@@ -72,7 +72,7 @@ func ClearFileInfoAndDownloadTask(fileHash string, w http.ResponseWriter) {
 func ReqClearDownloadTask(ctx context.Context, conn core.WriteCloser) {
 	var target protos.ReqClearDownloadTask
 	if requests.UnmarshalData(ctx, &target) {
-		task.DeleteDownloadTask(target.WalletAddress, target.WalletAddress)
+		task.DeleteDownloadTask(target.WalletAddress, target.WalletAddress, "")
 	}
 }
 
@@ -88,7 +88,7 @@ func GetVideoSlice(sliceInfo *protos.DownloadSliceInfo, fInfo *protos.RspFileSto
 	if setting.CheckLogin() {
 		utils.DebugLog("taskid ======= ", sliceInfo.TaskId)
 		sliceHash := sliceInfo.SliceStorageInfo.SliceHash
-		if file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceHash, fInfo.SavePath) {
+		if file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceHash, fInfo.SavePath, fInfo.ReqId) {
 			utils.Log("slice exist already,", sliceHash)
 			slicePath := file.GetDownloadTmpPath(fInfo.FileHash, sliceHash, fInfo.SavePath)
 			video, _ := ioutil.ReadFile(slicePath)
@@ -96,7 +96,7 @@ func GetVideoSlice(sliceInfo *protos.DownloadSliceInfo, fInfo *protos.RspFileSto
 		} else {
 			req := requests.ReqDownloadSliceData(fInfo, sliceInfo)
 			utils.Log("Send request for downloading slice: ", sliceInfo.SliceStorageInfo.SliceHash)
-			SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req)
+			SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
 			if err := storeResponseWriter(req.ReqId, w); err != nil {
 				w.WriteHeader(setting.FAILCode)
 				w.Write(httpserv.NewErrorJson(setting.FAILCode, "Get video segment time out").ToBytes())
@@ -131,12 +131,12 @@ func GetVideoSlices(fInfo *protos.RspFileStorageInfo) {
 		}
 	} else {
 		for _, sliceInfo := range videoCacheTask.Slices {
-			if !file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceInfo.SliceStorageInfo.SliceHash, fInfo.SavePath) {
+			if !file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceInfo.SliceStorageInfo.SliceHash, fInfo.SavePath, fInfo.ReqId) {
 
 				req := requests.ReqDownloadSliceData(fInfo, sliceInfo)
 				req.IsVideoCaching = true
 				if req != nil {
-					SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req)
+					SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
 				}
 			}
 		}
@@ -167,13 +167,13 @@ func cacheSlice(videoCacheTask *task.VideoCacheTask, fInfo *protos.RspFileStorag
 			}
 			sliceInfo := videoCacheTask.Slices[0]
 			utils.DebugLog("start Download!!!!!", sliceInfo.SliceNumber)
-			if file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceInfo.SliceStorageInfo.SliceHash, fInfo.SavePath) {
+			if file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceInfo.SliceStorageInfo.SliceHash, fInfo.SavePath, fInfo.ReqId) {
 				utils.DebugLog("slice exist already ", sliceInfo.SliceNumber)
 				videoCacheTask.DownloadCh <- true
 			} else {
 				req := requests.ReqDownloadSliceData(fInfo, sliceInfo)
 				req.IsVideoCaching = true
-				SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req)
+				SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
 			}
 
 			videoCacheTask.Slices = append(videoCacheTask.Slices[:0], videoCacheTask.Slices[0+1:]...)
@@ -184,13 +184,13 @@ func cacheSlice(videoCacheTask *task.VideoCacheTask, fInfo *protos.RspFileStorag
 func GetHlsInfo(fInfo *protos.RspFileStorageInfo) *file.HlsInfo {
 	sliceInfo := GetSliceInfoBySliceNumber(fInfo, uint64(1))
 	sliceHash := sliceInfo.SliceStorageInfo.SliceHash
-	if !file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceHash, fInfo.SavePath) {
+	if !file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceHash, fInfo.SavePath, fInfo.ReqId) {
 		req := requests.ReqDownloadSliceData(fInfo, sliceInfo)
-		SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req)
+		SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
 
 		start := time.Now().Unix()
 		for {
-			if file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceHash, fInfo.SavePath) {
+			if file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceHash, fInfo.SavePath, fInfo.ReqId) {
 				return file.LoadHlsInfo(fInfo.FileHash, sliceHash, fInfo.SavePath)
 			} else {
 				select {
@@ -230,8 +230,8 @@ func RspFileStorageInfo(ctx context.Context, conn core.WriteCloser) {
 		utils.DebugLog("file hash", target.FileHash)
 		if target.Result.State == protos.ResultState_RES_SUCCESS {
 			utils.Log("download starts: ")
-			task.CleanDownloadFileAndConnMap(target.FileHash)
-			task.DownloadFileMap.Store(target.FileHash, &target)
+			task.CleanDownloadFileAndConnMap(target.FileHash, target.ReqId)
+			task.DownloadFileMap.Store(target.FileHash + target.ReqId, &target)
 			task.AddDownloadTask(&target)
 			if target.IsVideoStream {
 				return

--- a/pp/event/timeout_handler.go
+++ b/pp/event/timeout_handler.go
@@ -19,7 +19,7 @@ func (handler *DownloadTimeoutHandler) Handle(message *msg.RelayMsgBuf) {
 
 	}
 
-	dTask, ok := task.GetDownloadTask(target.FileHash, target.WalletAddress)
+	dTask, ok := task.GetDownloadTask(target.FileHash, target.WalletAddress, task.LOCAL_REQID)
 	if !ok {
 		return
 	}

--- a/pp/requests/requests.go
+++ b/pp/requests/requests.go
@@ -236,9 +236,23 @@ func RequestUploadFileData(paths, storagePath, reqID, ownerWalletAddress string,
 	}
 	task.UploadProgressMap.Store(fileHash, p)
 	// if isCover {
-	// 	os.Remove(path)
+	//	os.Remove(path)
 	// }
 	return req
+}
+
+// RequestDownloadFile the entry for rpc remote download
+func RequestDownloadFile(fileHash, walletAddr string) (*protos.ReqFileStorageInfo, string) {
+	// file's request id is used for identifying the download session
+    fileReqId := uuid.New().String()
+
+	// download file uses fileHash + fileReqId as the key
+	file.SaveRemoteFileHash(fileHash + fileReqId, "rpc:", 0)
+
+	// path: mesh network address
+	sdmPath := "sdm://" + walletAddr + "/" + fileHash
+	req := ReqFileStorageInfoData(sdmPath, "", fileReqId, setting.WalletAddress, "", false, nil)
+	return req, fileReqId
 }
 
 func RspDownloadSliceData(target *protos.ReqDownloadSlice) *protos.RspDownloadSlice {
@@ -389,6 +403,7 @@ func ReqReportDownloadResultData(target *protos.RspDownloadSlice, isPP bool) *pr
 	}
 	if isPP {
 		utils.Log("PP ReportDownloadResult ")
+
 		if dlTask, ok := task.DownloadTaskMap.Load(target.FileHash + target.WalletAddress); ok {
 			downloadTask := dlTask.(*task.DownloadTask)
 			utils.DebugLog("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^downloadTask", downloadTask)

--- a/pp/serv/terminal_cmd.go
+++ b/pp/serv/terminal_cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/pp/types"
+	"github.com/stratosnet/sds/pp/task"
 	"github.com/stratosnet/sds/utils"
 )
 
@@ -261,7 +262,7 @@ func (api *terminalCmd) Download(param []string) (CmdResult, error) {
 	if len(param) == 2 {
 		saveAs = param[1]
 	}
-	event.GetFileStorageInfo(param[0], "", "", setting.WalletAddress, saveAs, false, nil)
+	event.GetFileStorageInfo(param[0], "", task.LOCAL_REQID, setting.WalletAddress, saveAs, false, nil)
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 


### PR DESCRIPTION
This PR is on top of PR #192 (feat/QB-1199 RPC download file). The first two commits are from #192. When #192 is merged, this branch will be rebased.

* ReqId of the file is used for identifying the download sessions
* LOCAL_REQID is used for local download, and a generated uuid is used for remote download
* keep a map to match slice ReqId to a file
* different way to handle the end of download - no local tem file nor csv file for remote download
* ReqId included in download related message

