### PR TITLE
Fix/QB-1290 Handshake panic

### DIFF
--- a/framework/client/cf/conn.go
+++ b/framework/client/cf/conn.go
@@ -287,7 +287,6 @@ func (cc *ClientConn) handshake() error {
 	core.HandshakeChanMap.Store(strconv.FormatUint(uint64(channelId), 10), handshakeChan)
 	defer func() {
 		core.HandshakeChanMap.Delete(cc.GetRemoteAddr())
-		close(handshakeChan)
 	}()
 
 	// Write the connection type as first message


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-1290

- Don't close the handshake channel, so the server won't panic and crash even if there is time-out (channel will get garbage collected anyway)