### PR TITLE
feet/QB-1289 monitor service protected by token

### DIFF
--- a/cmd/ppd/node.go
+++ b/cmd/ppd/node.go
@@ -41,6 +41,7 @@ func nodePreRunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	setting.MonitorInitialToken = serv.CreateInitialToken()
 	setting.TrafficLogPath = filepath.Join(setting.GetRootPath(), "./tmp/logs/traffic_dump.log")
 	trafficLogger := utils.NewTrafficLogger(setting.TrafficLogPath, false, true)
 	trafficLogger.SetLogLevel(utils.Info)

--- a/cmd/ppd/terminal.go
+++ b/cmd/ppd/terminal.go
@@ -47,6 +47,7 @@ func run(cmd *cobra.Command, args []string, isExec bool) {
 		"ver                                        			version\n" +
 		"monitor                                    			show monitor\n" +
 		"stopmonitor                                			stop monitor\n" +
+		"monitortoken                                   		show token for pp monitor service" +
 		"config  <key> <value>                      			set config key value\n" +
 		"getoz <walletAddress> ->password           			get current ozone balance\n" +
 		"status			                                        get current resource node status\n"
@@ -191,7 +192,9 @@ func run(cmd *cobra.Command, args []string, isExec bool) {
 	cancelget := func(line string, param []string) bool {
 		return callRpc(c, "cancelGet", param)
 	}
-
+	monitortoken := func(line string, param []string) bool {
+		return callRpc(c, "monitorToken", param)
+	}
 	//TODO move to pp api later
 	//if setting.Config.WalletAddress != "" && setting.Config.InternalPort != "" {
 	//	serv.Login(setting.Config.WalletAddress, setting.Config.WalletPassword)
@@ -261,6 +264,7 @@ func run(cmd *cobra.Command, args []string, isExec bool) {
 	console.Mystdin.RegisterProcessFunc("pauseget", pauseget, true)
 	console.Mystdin.RegisterProcessFunc("pauseput", pauseput, true)
 	console.Mystdin.RegisterProcessFunc("cancelget", cancelget, true)
+	console.Mystdin.RegisterProcessFunc("monitortoken", monitortoken, true)
 
 	if isExec {
 		if len(args) > 0 {

--- a/pp/serv/monitor.go
+++ b/pp/serv/monitor.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/setting"
@@ -45,7 +47,19 @@ type OnlineStateResult struct {
 }
 
 type ParamTrafficInfo struct {
+	SubId string `json:"subid"`
 	Lines uint64 `json:"lines"`
+}
+type ParamGetDiskUsage struct {
+	SubId string `json:"subid"`
+}
+
+type ParamGetPeerList struct {
+	SubId string `json:"subid"`
+}
+
+type ParamGetOnLineState struct {
+	SubId string `json:"subid"`
 }
 
 type monitorApi struct {
@@ -66,32 +80,66 @@ func monitorAPI() []rpc.API {
 	}
 }
 
+// key: rpc.Subscription, value: chan TranfficInfo
 var subscriptions = &sync.Map{}
+
+// key: rpc.Subscription.ID (string), value: struct{} (nothing)
+var subscribedIds = &sync.Map{}
 
 // subscribeTrafficInfo subscribe the channel to receive the traffic info from the generator
 func subscribeTrafficInfo(s rpc.Subscription, c chan TrafficInfo) {
-	utils.DebugLog("Subscribed TI")
+	var e struct{}
+	subscribedIds.Store(string(s.ID), e)
 	subscriptions.Store(s, c)
 }
 
 // unsubscribeTrafficInfo unsubscribe the channel listening to the traffic info
 func unsubscribeTrafficInfo(s rpc.Subscription) {
-	utils.DebugLog("UN-subscribed TI")
+	subscribedIds.Delete(s.ID)
 	subscriptions.Delete(s)
 }
 
 // TrafficInfoToMonitorClient traffic info generator calls this to feed the notifiers to the subscribed clients
 func TrafficInfoToMonitorClient(t TrafficInfo) {
-	utils.DebugLog("Sending TI to clients:")
 	subscriptions.Range(func(k, v interface{}) bool {
-		utils.DebugLog("-->")
 		v.(chan TrafficInfo) <- t
 		return true
 	})
 }
 
+// CreateInitialToken the initial token is used to generate all following tokens
+func CreateInitialToken() string {
+	epoch := strconv.FormatInt(time.Now().Unix(), 10)
+	return utils.CalcHash([]byte(epoch + setting.P2PAddress))
+}
+
+// calculateToken
+func calculateToken(time int64) string {
+	t := strconv.FormatInt(time, 10)
+	return utils.CalcHash([]byte(t + setting.MonitorInitialToken))
+}
+
+// GetCurrentToken
+func GetCurrentToken() string {
+	return calculateToken(time.Now().Unix() / 3600)
+}
+
+// verifyToken verify if the input token matches the generated token
+func verifyToken(token string) bool {
+	t := time.Now().Unix() / 3600
+	if calculateToken(t) == token {
+		return true
+	} else if calculateToken(t-1) == token {
+		return true
+	}
+	return false
+}
+
 // GetTrafficData fetch the traffic data from the file
-func (api *monitorApi) GetTrafficData(param ParamTrafficInfo) *TrafficDataResult {
+func (api *monitorApi) GetTrafficData(param ParamTrafficInfo) (*TrafficDataResult, error) {
+	if _, found := subscribedIds.Load(param.SubId); !found {
+		return nil, errors.New("client hasn't subscribed to the service")
+	}
 	lines := utils.GetLastLinesFromTrafficLog(setting.TrafficLogPath, param.Lines)
 
 	var ts []TrafficInfo
@@ -102,7 +150,7 @@ func (api *monitorApi) GetTrafficData(param ParamTrafficInfo) *TrafficDataResult
 		date := line[17:36]
 		_, content, found := strings.Cut(line, "{")
 		if !found {
-			return &TrafficDataResult{Return: "-1"}
+			return &TrafficDataResult{Return: "-1"}, nil
 		}
 
 		content = "{" + content
@@ -114,11 +162,15 @@ func (api *monitorApi) GetTrafficData(param ParamTrafficInfo) *TrafficDataResult
 		ts = append(ts, t.TrafficInfo)
 	}
 
-	return &TrafficDataResult{Return: "0", TraffInfo: ts}
+	return &TrafficDataResult{Return: "0", TraffInfo: ts}, nil
 }
 
 // GetDiskUsage the size of files in setting.Config.StorehousePath, not the disk usage of the computer
-func (api *monitorApi) GetDiskUsage() *DiskUsageResult {
+func (api *monitorApi) GetDiskUsage(param ParamGetDiskUsage) (*DiskUsageResult, error) {
+	if _, found := subscribedIds.Load(param.SubId); !found {
+		return nil, errors.New("client hasn't subscribed to the service")
+	}
+
 	var size int64
 	filepath.Walk(setting.Config.StorehousePath, func(_ string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -130,11 +182,15 @@ func (api *monitorApi) GetDiskUsage() *DiskUsageResult {
 		return err
 	})
 
-	return &DiskUsageResult{Return: "0", DataHost: size}
+	return &DiskUsageResult{Return: "0", DataHost: size}, nil
 }
 
 // GetPeerList the peer pp list
-func (api *monitorApi) GetPeerList() *PeerListResult {
+func (api *monitorApi) GetPeerList(param ParamGetPeerList) (*PeerListResult, error) {
+	if _, found := subscribedIds.Load(param.SubId); !found {
+		return nil, errors.New("client hasn't subscribed to the service")
+	}
+
 	pl, t := peers.GetPPList()
 	var peer PeerInfo
 	var peers []PeerInfo
@@ -153,11 +209,11 @@ func (api *monitorApi) GetPeerList() *PeerListResult {
 		Return:   "0",
 		Total:    t,
 		PeerList: peers,
-	}
+	}, nil
 }
 
 // GetOnlineState if the pp node is online
-func (api *monitorApi) GetOnlineState() *OnlineStateResult {
+func (api *monitorApi) GetOnlineState(param ParamGetOnLineState) *OnlineStateResult {
 	if setting.OnlineTime == 0 {
 	}
 	return &OnlineStateResult{
@@ -168,7 +224,10 @@ func (api *monitorApi) GetOnlineState() *OnlineStateResult {
 }
 
 // Subscription client calls the method monitor_subscribe with this function as the parameter
-func (api *monitorApi) Subscription(ctx context.Context) (*rpc.Subscription, error) {
+func (api *monitorApi) Subscription(ctx context.Context, token string) (*rpc.Subscription, error) {
+	if !verifyToken(token) {
+		return nil, errors.New("failed token check")
+	}
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported

--- a/pp/serv/terminal_cmd.go
+++ b/pp/serv/terminal_cmd.go
@@ -402,3 +402,8 @@ func (api *terminalCmd) CancelGet(param []string) (CmdResult, error) {
 	event.DownloadSliceCancel(param[0], "", nil)
 	return CmdResult{Msg: DefaultMsg}, nil
 }
+
+func (api *terminalCmd) MonitorToken(param []string) (CmdResult, error) {
+	utils.Log("Monitor token is:", GetCurrentToken())
+	return CmdResult{Msg: DefaultMsg}, nil
+}

--- a/pp/setting/ppinfo.go
+++ b/pp/setting/ppinfo.go
@@ -14,7 +14,7 @@ var IsLoginToSP = false
 
 var State uint32 = ppTypes.PP_INACTIVE
 
-var OnlineTime int64  = 0
+var OnlineTime int64 = 0
 
 var IsStartMining = false // Is the node currently mining
 
@@ -38,6 +38,8 @@ var P2PPublicKey []byte
 var P2PPrivateKey []byte
 
 var SPMap = &sync.Map{}
+
+var MonitorInitialToken string
 
 func GetNetworkID() types.NetworkID {
 	return types.NetworkID{


### PR DESCRIPTION
* an initial token is generated when node start
* starting time is included to generate the token in order to make it unique and unguessable 
* command "monitortoken " is added to PP terminal to show the current token
* token is updated every 3600 second
* the client side need provide token to subscribe 
* the current token or the previous one could be regarded as valid
* once subscription is done, the subscription ID given by rpc stack will be carried in all following requests, otherwise an error will be generated.
