### PR TITLE
feat/QB-1289/token for pp monitor

### DIFF
--- a/pp/serv/monitor.go
+++ b/pp/serv/monitor.go
@@ -151,14 +151,14 @@ func (api *monitorApi) GetTrafficData(param ParamTrafficInfo) (*TrafficDataResul
 
 		content := strings.SplitN(line, "{", 2)
 		if len(content) < 2 {
-			return &TrafficDataResult{Return: "-1"}
+			return &TrafficDataResult{Return: "-1"}, nil
 		}
 
 		c := "{" + content[1]
 
 		var t TrafficDumpInfo
 		if err := json.Unmarshal([]byte(c), &t); err != nil {
-			return &TrafficDataResult{Return: "-1"}
+			return &TrafficDataResult{Return: "-1"}, nil
 		}
 
 		t.TrafficInfo.TimeStamp = date


### PR DESCRIPTION
After (https://github.com/stratosnet/sds/commit/d1a41ab14a2036be2feaa4551e4fc379983ec6f8) is applied on feature QB-1266 "api pp node monitor", further change for QB-1289 "token for pp monitor" is needed, and fixed the build
