### PR TITLE
WIP: feat/QB-1310 high cpu rate test

### DIFF
--- a/example/frameworktest/client.go
+++ b/example/frameworktest/client.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/stratosnet/sds/framework/client/cf"
+	"github.com/stratosnet/sds/msg"
+	"github.com/stratosnet/sds/msg/header"
+	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/utils"
+	"math/rand"
+	"net"
+	"time"
+)
+
+// counter number of clients in this test
+var counter uint64 = 0
+
+func NewClient() {
+	// dail the server
+	tcpAddr, err := net.ResolveTCPAddr("tcp4", "127.0.0.1:55555")
+	if err != nil {
+		utils.ErrorLogf("resolve TCP address error: %v", err)
+	}
+	c, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		utils.ErrorLogf("connect failed", err)
+		return
+	}
+	serverPortOpt := cf.ServerPortOption(55555)
+	options := []cf.ClientOption{
+		cf.BufferSizeOption(100),
+		cf.LogOpenOption(true),
+		serverPortOpt,
+	}
+
+	conn := cf.CreateClientConn(0, c, options...)
+	conn.Start()
+
+	counter++
+	// loc_c identifier of this client
+	loc_c := counter
+
+	// message
+	cmd := "RspBdVer"
+	req := &protos.RspBadVersion{
+		Version:        int32(7),
+		MinimumVersion: int32(7),
+		Command:        cmd,
+	}
+	data, err := proto.Marshal(req)
+	if err != nil {
+		utils.ErrorLog(err)
+		return
+	}
+	message := &msg.RelayMsgBuf{
+		MSGHead: header.MakeMessageHeader(1, 7, uint32(len(data)), header.RspBadVersion, utils.ZeroId()),
+		MSGData: data,
+	}
+
+	// random time to close this client
+	ctime := rand.Intn(100)
+	var done = make(chan bool)
+	go func() {
+		for {
+			// random interval to send a message to the server
+			t := rand.Intn(300)
+			select {
+			case <-time.After(time.Millisecond * time.Duration(10) * time.Duration(t+1)):
+				conn.Write(message)
+
+			case <-done:
+				fmt.Println("close up the connection")
+				conn.ClientClose()
+				counter--
+				return
+			}
+		}
+	}()
+	select {
+	case <-time.After(time.Second * time.Duration(ctime+1)):
+		// this condition is used for control which client to close
+		if loc_c == 950 {
+			done <- true
+		}
+	}
+}
+
+func main() {
+	utils.NewDefaultLogger("./logs/client.log", true, true)
+
+	for {
+		select {
+		// start a client every 50 ms up to 1000 clients
+		case <-time.After(time.Millisecond * 5):
+			if counter < 1000 {
+				go NewClient()
+			}
+		}
+	}
+}

--- a/example/frameworktest/server.go
+++ b/example/frameworktest/server.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/stratosnet/sds/framework/core"
+	"github.com/stratosnet/sds/msg"
+	"github.com/stratosnet/sds/msg/header"
+	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/utils"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"runtime"
+	"runtime/pprof"
+	"syscall"
+	"time"
+)
+
+var (
+	dafualt_prof = "server.prof"
+)
+
+func main() {
+	utils.NewDefaultLogger("./logs/server.log", true, true)
+
+	var counter int64 = 0
+	// pprof
+	f, err := os.Create(dafualt_prof)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	signal.Notify(make(chan os.Signal), syscall.SIGPROF)
+	if err := pprof.StartCPUProfile(f); err != nil {
+		log.Fatal("could not start CPU profile: ", err)
+	}
+	defer pprof.StopCPUProfile()
+
+	// server
+	host := "0.0.0.0:55555"
+	netListen, err := net.Listen("tcp", host)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// message
+	cmd := "RspBdVer"
+	req := &protos.RspBadVersion{
+		Version:        int32(7),
+		MinimumVersion: int32(7),
+		Command:        cmd,
+	}
+	data, err := proto.Marshal(req)
+	if err != nil {
+		utils.ErrorLog(err)
+		return
+	}
+	message := &msg.RelayMsgBuf{
+		MSGHead: header.MakeMessageHeader(1, 7, uint32(len(data)), header.RspBadVersion, utils.ZeroId()),
+		MSGData: data,
+	}
+
+	server := core.CreateServer(
+		//core.OnConnectOption(server.OnConnectOption),
+		//core.OnCloseOption(server.OnCloseOption),
+		////core.MaxConnectionsOption(utils.MaxConnections),
+		core.MaxConnectionsOption(12000),
+		core.MaxFlowOption(125*1024*1024),
+		//core.MinAppVersionOption(server.Conf.Version.MinAppVer),
+		//core.P2pAddressOption(server.p2pAddress),
+	)
+	log.Print("start framework server")
+	go server.Start(netListen)
+	go func() {
+		for {
+			select {
+			case <-time.After(time.Second * 5):
+				fmt.Println("Num Goroutine:", runtime.NumGoroutine())
+				fmt.Println("Counter:", core.Test_counter)
+				server.Broadcast(message)
+				counter++
+			}
+		}
+	}()
+
+	select {
+	// set test duration to 10 min and gracefully return with profiler file well written
+	case <-time.After(time.Minute * 10):
+		return
+	}
+}

--- a/framework/core/server.go
+++ b/framework/core/server.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"github.com/stratosnet/sds/metrics"
 	"net"
 	"strings"
@@ -158,8 +159,17 @@ func (s *Server) Start(l net.Listener) error {
 	}
 
 	var tempDelay time.Duration
+	// WL: QB-1310: DEBUG
+	var counter uint64 = 0
+	// WL: DEBUG END
 	for {
 		spbConn, err := l.Accept()
+		// WL: QB-1310: DEBUG
+		counter++
+		if counter%100 == 0 {
+			fmt.Println("Connections:", counter)
+		}
+		// WL: DEBUG END
 		if err != nil {
 			if ne, ok := err.(net.Error); ok && ne.Temporary() {
 				if tempDelay == 0 {

--- a/framework/core/utils.go
+++ b/framework/core/utils.go
@@ -94,3 +94,12 @@ func ReadEncryptedHeaderAndBody(c net.Conn, privKey []byte, maxBodySize int) (pl
 	plaintext, err = encryption.DecryptAES(privKey, buffer, nonce)
 	return plaintext, bytesRead, err
 }
+
+// WL: QB-1310: DEBUG
+func ReadRawMsg(c net.Conn) (plaintext []byte, err error) {
+	buffer := make([]byte, 8)
+	_, err = io.ReadFull(c, buffer)
+	return buffer, err
+}
+
+// WL: DEBUG END


### PR DESCRIPTION
This pr is only for review of test code.
There were 1000 client conns connected to a server
At random time, one of the client conns closed by calling conn.ClientClose()

observed:
- on server side, not util the next writing operation, the client close event was noticed
- the cpu usage of readLoop() started to hike when client close the conn
- the writing failure in writeLoop() triggers the server conn close; CPU rate normally went back to the rate before
- in case of returning from the defer function without closing the server conn. High CPU rate in readLoop continued.
 
Maybe it was caused by the conn options. OnCloseOption was not set.