### PR TITLE
feat/QB-1250 terminal log optimize

### DIFF
--- a/cmd/ppd/main.go
+++ b/cmd/ppd/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	err := rootCmd.Execute()
 	if err != nil {
-		utils.ErrorLog(err)
+		fmt.Println(err.Error())
 	}
 	return
 }
@@ -72,6 +72,7 @@ func getTerminalCmd() *cobra.Command {
 		PreRunE: terminalPreRunE,
 		Run:     execute,
 	}
+	execCmd.Flags().BoolP(verboseFlag, "v", false, "output logs")
 	cmd.AddCommand(execCmd)
 	return cmd
 }

--- a/framework/client/cf/conn.go
+++ b/framework/client/cf/conn.go
@@ -596,6 +596,7 @@ func asyncWrite(c *ClientConn, m *msg.RelayMsgBuf, ctx context.Context) (err err
 		return
 	}
 
+	m.MSGHead.ReqId = reqId
 	core.TimoutMap.Store(reqId, m)
 
 	return

--- a/framework/core/codec.go
+++ b/framework/core/codec.go
@@ -3,15 +3,19 @@ package core
 //event register
 import (
 	"context"
+
 	"github.com/stratosnet/sds/msg"
+	"github.com/stratosnet/sds/utils"
 )
 
 type ctxkey string
 
 const (
-	messageCtxKey ctxkey = "message"
-	serverCtxKey  ctxkey = "server"
-	netIDCtxKey   ctxkey = "netid"
+	messageCtxKey     ctxkey = "message"
+	serverCtxKey      ctxkey = "server"
+	netIDCtxKey       ctxkey = "netid"
+	reqIDCtxKey       ctxkey = "reqId"
+	parentReqIDCtxKey ctxkey = "parentReqId"
 )
 
 var (
@@ -69,4 +73,48 @@ func CreateContextWithNetID(ctx context.Context, netID int64) context.Context {
 // NetIDFromContext
 func NetIDFromContext(ctx context.Context) int64 {
 	return ctx.Value(netIDCtxKey).(int64)
+}
+
+func InheritRpcLoggerFromParentReqId(ctx context.Context, reqId int64) {
+	if ctx == nil || ctx.Value(parentReqIDCtxKey) == nil {
+		return
+	}
+	parentReqId := ctx.Value(parentReqIDCtxKey).(int64)
+	if logger, ok := utils.RpcLoggerMap.Load(parentReqId); ok {
+		utils.RpcLoggerMap.Store(reqId, logger)
+	}
+}
+
+func GetReqIdFromContext(ctx context.Context) int64 {
+	if ctx == nil || ctx.Value(reqIDCtxKey) == nil {
+		return 0
+	}
+
+	reqId := ctx.Value(reqIDCtxKey).(int64)
+	return reqId
+}
+
+func GetParentReqIdFromContext(ctx context.Context) int64 {
+	if ctx == nil || ctx.Value(parentReqIDCtxKey) == nil {
+		return 0
+	}
+
+	parentReqId := ctx.Value(parentReqIDCtxKey).(int64)
+	return parentReqId
+}
+
+func CreateContextWithReqId(ctx context.Context, reqId int64) context.Context {
+	return context.WithValue(ctx, reqIDCtxKey, reqId)
+}
+
+func CreateContextWithParentReqId(ctx context.Context, reqId int64) context.Context {
+	return context.WithValue(ctx, parentReqIDCtxKey, reqId)
+}
+
+func CreateContextWithParentReqIdAsReqId(ctx context.Context) context.Context {
+	if ctx != nil && ctx.Value(parentReqIDCtxKey) != nil {
+		parentReqId := ctx.Value(parentReqIDCtxKey).(int64)
+		return context.WithValue(ctx, reqIDCtxKey, parentReqId)
+	}
+	return ctx
 }

--- a/framework/core/server.go
+++ b/framework/core/server.go
@@ -2,11 +2,12 @@ package core
 
 import (
 	"context"
-	"github.com/stratosnet/sds/metrics"
 	"net"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/stratosnet/sds/metrics"
 
 	"github.com/alex023/clock"
 	"github.com/stratosnet/sds/msg"
@@ -335,10 +336,10 @@ func P2pAddressOption(p2pAddress string) ServerOption {
 }
 
 // Unicast
-func (s *Server) Unicast(netid int64, msg *msg.RelayMsgBuf) error {
+func (s *Server) Unicast(ctx context.Context, netid int64, msg *msg.RelayMsgBuf) error {
 	v, ok := s.conns.Load(netid)
 	if ok {
-		return v.Write(msg)
+		return v.Write(msg, ctx)
 	}
 	Mylog(s.opts.logOpen, "conn id not found", msg)
 	return nil
@@ -347,7 +348,7 @@ func (s *Server) Unicast(netid int64, msg *msg.RelayMsgBuf) error {
 // Broadcast
 func (s *Server) Broadcast(msg *msg.RelayMsgBuf) {
 	s.conns.Range(func(id int64, conn *ServerConn) bool {
-		if err := conn.Write(msg); err != nil {
+		if err := conn.Write(msg, context.Background()); err != nil {
 			Mylog(s.opts.logOpen, "broadcast error:", err, "conn id:", id)
 			return false
 		}

--- a/msg/header/header.go
+++ b/msg/header/header.go
@@ -15,14 +15,13 @@ type MessageHead struct {
 }
 
 // MakeMessageHeader
-func MakeMessageHeader(tag int16, version uint16, length uint32, cmd string, reqId int64) MessageHead {
+func MakeMessageHeader(tag int16, version uint16, length uint32, cmd string) MessageHead {
 	var cmdByte = []byte(cmd)[:8]
 	return MessageHead{
 		Tag:     tag,
 		Len:     length,
 		Cmd:     cmdByte,
 		Version: version,
-		ReqId:   reqId,
 	}
 }
 

--- a/pp/api/create_wallet.go
+++ b/pp/api/create_wallet.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"regexp"
@@ -87,6 +88,6 @@ func createWallet(w http.ResponseWriter, request *http.Request) {
 	}
 	utils.DebugLog("add", data1)
 	setting.WalletAddress = walletAddressString
-	serv.Login(setting.WalletAddress, password)
+	serv.Login(context.Background(), setting.WalletAddress, password)
 	w.Write(httpserv.NewJson(data1, setting.SUCCESSCode, "create wallet successfully").ToBytes())
 }

--- a/pp/api/delete_file.go
+++ b/pp/api/delete_file.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/stratosnet/sds/pp/event"
@@ -19,7 +20,7 @@ func deleteFile(w http.ResponseWriter, request *http.Request) {
 	//path := ""
 	if data["fileHash"] != nil {
 		fileHash = data["fileHash"].(string)
-		event.DeleteFile(fileHash, uuid.New().String(), w)
+		event.DeleteFile(context.Background(), fileHash, uuid.New().String(), w)
 	}
 
 	//if data["path"] != nil {

--- a/pp/api/delete_share.go
+++ b/pp/api/delete_share.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"context"
+	"net/http"
+
 	"github.com/stratosnet/sds/pp/event"
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/utils/httpserv"
-	"net/http"
 
 	"github.com/google/uuid"
 )
@@ -17,7 +19,7 @@ func deleteShare(w http.ResponseWriter, request *http.Request) {
 	shareID := ""
 	if data["shareID"] != nil {
 		shareID = data["shareID"].(string)
-		event.DeleteShare(shareID, uuid.New().String(), setting.WalletAddress, w)
+		event.DeleteShare(context.Background(), shareID, uuid.New().String(), setting.WalletAddress, w)
 	} else {
 		w.Write(httpserv.NewJson(nil, setting.FAILCode, "shareID is required").ToBytes())
 	}

--- a/pp/api/download_file.go
+++ b/pp/api/download_file.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -41,7 +42,7 @@ func downloadFile(w http.ResponseWriter, request *http.Request) {
 	}.String()
 	downTaskID := uuid.New().String()
 
-	event.GetFileStorageInfo(path, "", downTaskID, setting.WalletAddress, p.SaveAs, false, w)
+	event.GetFileStorageInfo(context.Background(), path, "", downTaskID, setting.WalletAddress, p.SaveAs, false, w)
 
 	type df struct {
 		TaskID             string `json:"taskID"`

--- a/pp/api/get_all_file.go
+++ b/pp/api/get_all_file.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/stratosnet/sds/pp/event"
@@ -49,6 +50,6 @@ func getAllFile(w http.ResponseWriter, request *http.Request) {
 		keyword = ""
 	}
 	if setting.CheckLogin() {
-		event.FindFileList(fileName, setting.WalletAddress, pageId, uuid.New().String(), keyword, fileType, isUp, w)
+		event.FindFileList(context.Background(), fileName, setting.WalletAddress, pageId, uuid.New().String(), keyword, fileType, isUp, w)
 	}
 }

--- a/pp/api/get_all_share_link.go
+++ b/pp/api/get_all_share_link.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"context"
 	"net/http"
+
 	"github.com/google/uuid"
 	"github.com/stratosnet/sds/pp/event"
 	"github.com/stratosnet/sds/pp/setting"
@@ -12,5 +14,5 @@ func getAllShareLink(w http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		return
 	}
-	event.GetAllShareLink(uuid.New().String(), setting.WalletAddress, 0, w)
+	event.GetAllShareLink(context.Background(), uuid.New().String(), setting.WalletAddress, 0, w)
 }

--- a/pp/api/get_share_file.go
+++ b/pp/api/get_share_file.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/stratosnet/sds/pp/event"
@@ -33,5 +34,5 @@ func getShareFile(w http.ResponseWriter, request *http.Request) {
 		saveAs = data["saveAs"].(string)
 	}
 
-	event.GetShareFile(keyword, sharePassword, saveAs, uuid.New().String(), setting.WalletAddress, w)
+	event.GetShareFile(context.Background(), keyword, sharePassword, saveAs, uuid.New().String(), setting.WalletAddress, w)
 }

--- a/pp/api/import_wallet.go
+++ b/pp/api/import_wallet.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"path/filepath"
 
@@ -76,5 +77,5 @@ func importWallet(w http.ResponseWriter, request *http.Request) {
 		},
 	}
 	w.Write(httpserv.NewJson(data1, setting.SUCCESSCode, "successfully import wallet").ToBytes())
-	serv.Login(setting.WalletAddress, password)
+	serv.Login(context.Background(), setting.WalletAddress, password)
 }

--- a/pp/api/share_file.go
+++ b/pp/api/share_file.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/stratosnet/sds/pp/event"
@@ -48,5 +49,5 @@ func shareFile(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	event.GetReqShareFile(uuid.New().String(), fileHash, pathHash, setting.WalletAddress, shareTime, isPrivate, w)
+	event.GetReqShareFile(context.Background(), uuid.New().String(), fileHash, pathHash, setting.WalletAddress, shareTime, isPrivate, w)
 }

--- a/pp/api/stream_video.go
+++ b/pp/api/stream_video.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
@@ -81,7 +82,7 @@ func streamVideoInfoCache(w http.ResponseWriter, req *http.Request) {
 		w.Write(httpserv.NewErrorJson(setting.FAILCode, "Failed to retrieve download task info").ToBytes())
 		return
 	}
-	event.GetVideoSlices(streamInfo.FileInfo, dTask)
+	event.GetVideoSlices(context.Background(), streamInfo.FileInfo, dTask)
 	ret, _ := json.Marshal(streamInfo)
 	w.Write(ret)
 }
@@ -246,7 +247,7 @@ func getStreamInfo(fileHash, ownerWalletAddress, walletAddress string, w http.Re
 		Owner: ownerWalletAddress,
 		Hash:  fileHash,
 	}.String()
-	event.GetFileStorageInfo(filePath, setting.VIDEOPATH, uuid.New().String(), walletAddress, "", true, w)
+	event.GetFileStorageInfo(context.Background(), filePath, setting.VIDEOPATH, uuid.New().String(), walletAddress, "", true, w)
 	var fInfo *protos.RspFileStorageInfo
 	start := time.Now().Unix()
 	for {

--- a/pp/api/stream_video.go
+++ b/pp/api/stream_video.go
@@ -56,6 +56,7 @@ type SliceInfo struct {
 }
 
 func streamVideoInfoCache(w http.ResponseWriter, req *http.Request) {
+	ctx := context.Background()
 	ownerWalletAddress, fileHash, err := parseFilePath(req.RequestURI)
 	if err != nil {
 		w.Write(httpserv.NewErrorJson(setting.FAILCode, err.Error()).ToBytes())
@@ -70,7 +71,7 @@ func streamVideoInfoCache(w http.ResponseWriter, req *http.Request) {
 
 	task.VideoCacheTaskMap.Delete(fileHash)
 	task.DownloadFileMap.Delete(fileHash + task.LOCAL_REQID)
-	streamInfo, err := getStreamInfo(fileHash, ownerWalletAddress, setting.WalletAddress, w)
+	streamInfo, err := getStreamInfo(ctx, fileHash, ownerWalletAddress, setting.WalletAddress, w)
 	if err != nil {
 		w.WriteHeader(setting.FAILCode)
 		w.Write(httpserv.NewErrorJson(setting.FAILCode, err.Error()).ToBytes())
@@ -82,12 +83,13 @@ func streamVideoInfoCache(w http.ResponseWriter, req *http.Request) {
 		w.Write(httpserv.NewErrorJson(setting.FAILCode, "Failed to retrieve download task info").ToBytes())
 		return
 	}
-	event.GetVideoSlices(context.Background(), streamInfo.FileInfo, dTask)
+	event.GetVideoSlices(ctx, streamInfo.FileInfo, dTask)
 	ret, _ := json.Marshal(streamInfo)
 	w.Write(ret)
 }
 
 func streamVideoInfoHttp(w http.ResponseWriter, req *http.Request) {
+	ctx := context.Background()
 	ownerWalletAddress, fileHash, err := parseFilePath(req.RequestURI)
 	if err != nil {
 		w.Write(httpserv.NewErrorJson(setting.FAILCode, err.Error()).ToBytes())
@@ -95,7 +97,7 @@ func streamVideoInfoHttp(w http.ResponseWriter, req *http.Request) {
 	}
 
 	task.DownloadFileMap.Delete(fileHash + task.LOCAL_REQID)
-	streamInfo, err := getStreamInfo(fileHash, ownerWalletAddress, setting.WalletAddress, w)
+	streamInfo, err := getStreamInfo(ctx, fileHash, ownerWalletAddress, setting.WalletAddress, w)
 	if err != nil {
 		w.WriteHeader(setting.FAILCode)
 		w.Write(httpserv.NewErrorJson(setting.FAILCode, err.Error()).ToBytes())
@@ -107,6 +109,7 @@ func streamVideoInfoHttp(w http.ResponseWriter, req *http.Request) {
 }
 
 func streamVideoP2P(w http.ResponseWriter, req *http.Request) {
+	ctx := context.Background()
 	sliceHash := parseSliceHash(req.URL)
 
 	body, err := verifyStreamReqBody(req)
@@ -133,7 +136,7 @@ func streamVideoP2P(w http.ResponseWriter, req *http.Request) {
 		WalletAddress: setting.WalletAddress,
 	}
 
-	event.GetVideoSlice(body.SliceInfo, fInfo, w)
+	event.GetVideoSlice(ctx, body.SliceInfo, fInfo, w)
 }
 
 func streamVideoHttp(w http.ResponseWriter, req *http.Request) {
@@ -242,12 +245,12 @@ func parseSliceHash(reqURL *url.URL) string {
 	return reqPath[strings.LastIndex(reqPath, "/")+1:]
 }
 
-func getStreamInfo(fileHash, ownerWalletAddress, walletAddress string, w http.ResponseWriter) (*StreamInfo, error) {
+func getStreamInfo(ctx context.Context, fileHash, ownerWalletAddress, walletAddress string, w http.ResponseWriter) (*StreamInfo, error) {
 	filePath := datamesh.DataMashId{
 		Owner: ownerWalletAddress,
 		Hash:  fileHash,
 	}.String()
-	event.GetFileStorageInfo(context.Background(), filePath, setting.VIDEOPATH, uuid.New().String(), walletAddress, "", true, w)
+	event.GetFileStorageInfo(ctx, filePath, setting.VIDEOPATH, uuid.New().String(), walletAddress, "", true, w)
 	var fInfo *protos.RspFileStorageInfo
 	start := time.Now().Unix()
 	for {
@@ -266,10 +269,10 @@ func getStreamInfo(fileHash, ownerWalletAddress, walletAddress string, w http.Re
 		}
 	}
 
-	hlsInfo := event.GetHlsInfo(fInfo)
+	hlsInfo := event.GetHlsInfo(ctx, fInfo)
 	segmentToSliceInfo := make(map[string]*protos.DownloadSliceInfo, 0)
 	for segment := range hlsInfo.SegmentToSlice {
-		segmentInfo := event.GetVideoSliceInfo(segment, fInfo)
+		segmentInfo := event.GetVideoSliceInfo(ctx, segment, fInfo)
 		segmentToSliceInfo[segment] = segmentInfo
 	}
 	StreamInfo := &StreamInfo{

--- a/pp/api/upload_cancel.go
+++ b/pp/api/upload_cancel.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"context"
+	"net/http"
+
 	"github.com/stratosnet/sds/pp/event"
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/utils/httpserv"
-	"net/http"
 
 	"github.com/google/uuid"
 )
@@ -28,7 +30,7 @@ func upCancel(w http.ResponseWriter, request *http.Request) {
 			}
 			list = append(list, l)
 			if val, ok := setting.UploadTaskIDMap.Load(l.TaskID); ok {
-				go event.UploadPause(val.(string), uuid.New().String(), w)
+				go event.UploadPause(context.Background(), val.(string), uuid.New().String(), w)
 			}
 			setting.UploadTaskIDMap.Delete(l.TaskID)
 			delete(setting.UpMap, l.TaskID)

--- a/pp/api/upload_file.go
+++ b/pp/api/upload_file.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -28,7 +29,7 @@ type uploadFileResult struct {
 }
 
 func uploadFile(w http.ResponseWriter, request *http.Request) {
-
+	ctx := context.Background()
 	// check differently for sp
 	if !setting.CheckLogin() {
 		_, _ = w.Write(httpserv.NewJson(nil, setting.FAILCode, "login first").ToBytes())
@@ -80,8 +81,8 @@ func uploadFile(w http.ResponseWriter, request *http.Request) {
 		}
 
 		if isFile {
-			f := requests.RequestUploadFileData(path, sdPath, "", setting.WalletAddress, false, false, false)
-			go peers.SendMessageToSPServer(f, header.ReqUploadFile)
+			f := requests.RequestUploadFileData(ctx, path, sdPath, "", setting.WalletAddress, false, false, false)
+			go peers.SendMessageToSPServer(ctx, f, header.ReqUploadFile)
 			taskID := uuid.New().String()
 			r := &uploadFileResult{
 				FailInfo: "",
@@ -131,7 +132,7 @@ func uploadFile(w http.ResponseWriter, request *http.Request) {
 					lastPaths = sdPath + "/" + lastPaths
 				}
 
-				f := requests.RequestUploadFileData(pathstring, lastPaths, "", setting.WalletAddress, false, false, false)
+				f := requests.RequestUploadFileData(ctx, pathstring, lastPaths, "", setting.WalletAddress, false, false, false)
 				utils.DebugLog("lastPaths>>>>", lastPaths)
 				utils.DebugLog("storagePath+relativePath", lastPaths, pathstring)
 				taskID := uuid.New().String()
@@ -152,7 +153,7 @@ func uploadFile(w http.ResponseWriter, request *http.Request) {
 				})
 				setting.UploadTaskIDMap.Store(r.TaskID, f.FileInfo.FileHash)
 				resultArr = append(resultArr, r)
-				go peers.SendMessageToSPServer(f, header.ReqUploadFile)
+				go peers.SendMessageToSPServer(ctx, f, header.ReqUploadFile)
 				utils.DebugLog("result>>>>>>>>>>>>>>", resultArr)
 
 			default:

--- a/pp/api/upload_pause.go
+++ b/pp/api/upload_pause.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
+	"net/http"
+
 	"github.com/stratosnet/sds/pp/event"
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/utils"
 	"github.com/stratosnet/sds/utils/httpserv"
-	"net/http"
 
 	"github.com/google/uuid"
 )
@@ -29,7 +31,7 @@ func upPause(w http.ResponseWriter, request *http.Request) {
 			}
 			list = append(list, l)
 			if val, ok := setting.UploadTaskIDMap.Load(f.(string)); ok {
-				go event.UploadPause(val.(string), uuid.New().String(), w)
+				go event.UploadPause(context.Background(), val.(string), uuid.New().String(), w)
 			}
 		}
 		result := make(map[string][]*pause, 0)

--- a/pp/event/activate.go
+++ b/pp/event/activate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
@@ -17,18 +18,18 @@ import (
 )
 
 // Activate Inactive PP node becomes active
-func Activate(amount, fee, gas int64) error {
+func Activate(ctx context.Context, amount, fee, gas int64) error {
 	// Query blockchain to know if this node is already a resource node
 	ppState, height, err := stratoschain.QueryResourceNodeState(setting.P2PAddress)
 	if err != nil {
-		utils.ErrorLog("Couldn't query node status from the blockchain", err)
+		pp.ErrorLog(ctx, "Couldn't query node status from the blockchain", err)
 		//return err
 	}
 
 	var activateReq *protos.ReqActivatePP
 	switch ppState.IsActive {
 	case types.PP_ACTIVE:
-		utils.Log("This node is already active on the blockchain. Waiting for SP node to confirm...")
+		pp.Log(ctx, "This node is already active on the blockchain. Waiting for SP node to confirm...")
 		activateReq = &protos.ReqActivatePP{
 			PpInfo:        setting.GetPPInfo(),
 			AlreadyActive: true,
@@ -36,7 +37,7 @@ func Activate(amount, fee, gas int64) error {
 	default:
 		activateReq, err = reqActivateData(amount, fee, gas, height)
 		if err != nil {
-			utils.ErrorLog("Couldn't build PP activate request", err)
+			pp.ErrorLog(ctx, "Couldn't build PP activate request", err)
 			return err
 		}
 	}
@@ -47,7 +48,7 @@ func Activate(amount, fee, gas int64) error {
 		logstring = fmt.Sprintf("Sending activate message to SP: %s, from: %s", "[no connected sp]", activateReq.PpInfo.P2PAddress)
 	}
 	utils.Log(logstring)
-	peers.SendMessageToSPServer(activateReq, header.ReqActivatePP)
+	peers.SendMessageToSPServer(ctx, activateReq, header.ReqActivatePP)
 	return nil
 }
 
@@ -59,13 +60,13 @@ func RspActivate(ctx context.Context, conn core.WriteCloser) {
 		return
 	}
 
-	utils.Log("get RspActivatePP", target.Result.State, target.Result.Msg)
+	pp.Log(ctx, "get RspActivatePP", target.Result.State, target.Result.Msg)
 	if target.Result.State != protos.ResultState_RES_SUCCESS {
 		return
 	}
 
 	if target.ActivationState == types.PP_ACTIVE {
-		utils.Log("Current node is already active")
+		pp.Log(ctx, "Current node is already active")
 		setting.State = target.ActivationState
 		return
 	}
@@ -74,14 +75,14 @@ func RspActivate(ctx context.Context, conn core.WriteCloser) {
 	case types.PP_INACTIVE:
 		err := stratoschain.BroadcastTxBytes(target.Tx)
 		if err != nil {
-			utils.ErrorLog("The activation transaction couldn't be broadcast", err)
+			pp.ErrorLog(ctx, "The activation transaction couldn't be broadcast", err)
 		} else {
-			utils.Log("The activation transaction was broadcast")
+			pp.Log(ctx, "The activation transaction was broadcast")
 		}
 	case types.PP_ACTIVE:
-		utils.Log("This node is already active")
+		pp.Log(ctx, "This node is already active")
 	case types.PP_UNBONDING:
-		utils.Log("This node is unbonding")
+		pp.Log(ctx, "This node is unbonding")
 	}
 }
 
@@ -99,6 +100,6 @@ func RspActivated(ctx context.Context, conn core.WriteCloser) {
 
 	// if autorun = true, bond pp to sp
 	if setting.IsAuto && !setting.IsLoginToSP {
-		peers.RegisterToSP(true)
+		peers.RegisterToSP(ctx, true)
 	}
 }

--- a/pp/event/delete_file.go
+++ b/pp/event/delete_file.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
@@ -16,9 +17,9 @@ import (
 )
 
 // DeleteFile
-func DeleteFile(fileHash, reqID string, w http.ResponseWriter) {
+func DeleteFile(ctx context.Context, fileHash, reqID string, w http.ResponseWriter) {
 	if setting.CheckLogin() {
-		peers.SendMessageDirectToSPOrViaPP(requests.ReqDeleteFileData(fileHash, reqID), header.ReqDeleteFile)
+		peers.SendMessageDirectToSPOrViaPP(ctx, requests.ReqDeleteFileData(fileHash, reqID), header.ReqDeleteFile)
 		storeResponseWriter(reqID, w)
 	} else {
 		notLogin(w)
@@ -27,7 +28,7 @@ func DeleteFile(fileHash, reqID string, w http.ResponseWriter) {
 
 // ReqDeleteFile
 func ReqDeleteFile(ctx context.Context, conn core.WriteCloser) {
-	peers.TransferSendMessageToSPServer(core.MessageFromContext(ctx))
+	peers.TransferSendMessageToSPServer(ctx, core.MessageFromContext(ctx))
 }
 
 // RspDeleteFile
@@ -36,13 +37,13 @@ func RspDeleteFile(ctx context.Context, conn core.WriteCloser) {
 	if requests.UnmarshalData(ctx, &target) {
 		if target.P2PAddress == setting.P2PAddress {
 			if target.Result.State == protos.ResultState_RES_SUCCESS {
-				utils.Log("delete success ", target.Result.Msg)
+				pp.Log(ctx, "delete success ", target.Result.Msg)
 			} else {
-				utils.Log("delete failed ", target.Result.Msg)
+				pp.Log(ctx, "delete failed ", target.Result.Msg)
 			}
 			putData(target.ReqId, HTTPDeleteFile, &target)
 		} else {
-			peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServByP2pAddress(ctx, target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 }
@@ -73,5 +74,5 @@ func ReqDeleteSlice(ctx context.Context, conn core.WriteCloser) {
 
 // RspDeleteSlice RspDeleteSlice
 func RspDeleteSlice(ctx context.Context, conn core.WriteCloser) {
-	peers.TransferSendMessageToSPServer(core.MessageFromContext(ctx))
+	peers.TransferSendMessageToSPServer(ctx, core.MessageFromContext(ctx))
 }

--- a/pp/event/download_file_wrong.go
+++ b/pp/event/download_file_wrong.go
@@ -6,35 +6,35 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
 	"github.com/stratosnet/sds/pp/task"
-	"github.com/stratosnet/sds/utils"
 )
 
-func CheckAndSendRetryMessage(dTask *task.DownloadTask) {
+func CheckAndSendRetryMessage(ctx context.Context, dTask *task.DownloadTask) {
 	if !dTask.NeedRetry() {
 		return
 	}
 	if f, ok := task.DownloadFileMap.Load(dTask.FileHash + task.LOCAL_REQID); ok {
 		fInfo := f.(*protos.RspFileStorageInfo)
-		peers.SendMessageToSPServer(requests.ReqDownloadFileWrongData(fInfo, dTask), header.ReqDownloadFileWrong)
+		peers.SendMessageToSPServer(ctx, requests.ReqDownloadFileWrongData(fInfo, dTask), header.ReqDownloadFileWrong)
 	}
 }
 
 // RspFileStorageInfo SP-PP , PP-P
 func RspDownloadFileWrong(ctx context.Context, conn core.WriteCloser) {
 	// PP check whether itself is the storage PP, if not transfer
-	utils.Log("get，RspDownloadFileWrong")
+	pp.Log(ctx, "get，RspDownloadFileWrong")
 	var target protos.RspFileStorageInfo
 	if requests.UnmarshalData(ctx, &target) {
-		utils.DebugLog("file hash", target.FileHash)
+		pp.DebugLog(ctx, "file hash", target.FileHash)
 		if target.Result.State == protos.ResultState_RES_SUCCESS {
-			utils.Log("download starts: ")
+			pp.Log(ctx, "download starts: ")
 			dTask, ok := task.GetDownloadTask(target.FileHash, target.WalletAddress, target.ReqId)
 			if !ok {
-				utils.DebugLog("cannot find the download task")
+				pp.DebugLog(ctx, "cannot find the download task")
 				return
 			}
 			dTask.RefreshTask(&target)
@@ -42,25 +42,25 @@ func RspDownloadFileWrong(ctx context.Context, conn core.WriteCloser) {
 				return
 			}
 			if _, ok := task.DownloadSpeedOfProgress.Load(target.FileHash + target.ReqId); !ok {
-				utils.Log("download has stopped")
+				pp.Log(ctx, "download has stopped")
 				return
 			}
 			for _, rsp := range target.SliceInfo {
-				utils.DebugLog("taskid ======= ", rsp.TaskId)
+				pp.DebugLog(ctx, "taskid ======= ", rsp.TaskId)
 				if file.CheckSliceExisting(target.FileHash, target.FileName, rsp.SliceStorageInfo.SliceHash, target.SavePath, target.ReqId) {
-					utils.Log("slice exist already,", rsp.SliceStorageInfo.SliceHash)
-					setDownloadSliceSuccess(rsp.SliceStorageInfo.SliceHash, dTask)
-					task.DownloadProgress(target.FileHash, target.ReqId, rsp.SliceStorageInfo.SliceSize)
+					pp.Log(ctx, "slice exist already,", rsp.SliceStorageInfo.SliceHash)
+					setDownloadSliceSuccess(ctx, rsp.SliceStorageInfo.SliceHash, dTask)
+					task.DownloadProgress(ctx, target.FileHash, target.ReqId, rsp.SliceStorageInfo.SliceSize)
 				} else {
-					utils.DebugLog("request download data")
+					pp.DebugLog(ctx, "request download data")
 					req := requests.ReqDownloadSliceData(&target, rsp)
-					SendReqDownloadSlice(target.FileHash, rsp, req, target.ReqId)
+					SendReqDownloadSlice(ctx, target.FileHash, rsp, req, target.ReqId)
 				}
 			}
-			utils.DebugLog("DownloadFileSlice(&target)", target)
+			pp.DebugLog(ctx, "DownloadFileSlice(&target)", target)
 		} else {
 			task.DeleteDownloadTask(target.FileHash, target.WalletAddress, task.LOCAL_REQID)
-			utils.Log("failed to download，", target.Result.Msg)
+			pp.Log(ctx, "failed to download，", target.Result.Msg)
 		}
 	}
 }

--- a/pp/event/download_slice.go
+++ b/pp/event/download_slice.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/stratosnet/sds/framework/client/cf"
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/peers"
@@ -29,7 +31,6 @@ const (
 func ReqDownloadSlice(ctx context.Context, conn core.WriteCloser) {
 	utils.Log("ReqDownloadSlice", conn)
 	var target protos.ReqDownloadSlice
-	reqId := requests.GetReqIdFromMessage(ctx)
 	if requests.UnmarshalData(ctx, &target) {
 		rsp := requests.RspDownloadSliceData(&target)
 
@@ -37,7 +38,7 @@ func ReqDownloadSlice(ctx context.Context, conn core.WriteCloser) {
 			rsp.Data = nil
 			rsp.Result.State = protos.ResultState_RES_FAIL
 			rsp.Result.Msg = "duplicate request for the same slice in the same download task"
-			peers.SendResponseMessageWithReqId(conn, rsp, header.RspDownloadSlice, reqId)
+			peers.SendMessage(ctx, conn, rsp, header.RspDownloadSlice)
 			return
 		}
 
@@ -45,7 +46,7 @@ func ReqDownloadSlice(ctx context.Context, conn core.WriteCloser) {
 			rsp.Data = nil
 			rsp.Result.State = protos.ResultState_RES_FAIL
 			rsp.Result.Msg = "signature validation failed"
-			peers.SendResponseMessageWithReqId(conn, rsp, header.RspDownloadSlice, reqId)
+			peers.SendMessage(ctx, conn, rsp, header.RspDownloadSlice)
 			return
 		}
 
@@ -53,18 +54,18 @@ func ReqDownloadSlice(ctx context.Context, conn core.WriteCloser) {
 			utils.DebugLog("cannot find slice, sliceHash: ", target.SliceInfo.SliceHash)
 			rsp.Result.State = protos.ResultState_RES_FAIL
 			rsp.Result.Msg = LOSE_SLICE_MSG
-			peers.SendResponseMessageWithReqId(conn, rsp, header.RspDownloadSlice, reqId)
+			peers.SendMessage(ctx, conn, rsp, header.RspDownloadSlice)
 			return
 		}
 
-		SendReportDownloadResult(rsp, true)
-		splitSendDownloadSliceData(rsp, conn, reqId)
+		SendReportDownloadResult(ctx, rsp, true)
+		splitSendDownloadSliceData(ctx, rsp, conn)
 
 		task.DownloadSliceTaskMap.Store(target.TaskId+target.SliceInfo.SliceHash, true)
 	}
 }
 
-func splitSendDownloadSliceData(rsp *protos.RspDownloadSlice, conn core.WriteCloser, reqId int64) {
+func splitSendDownloadSliceData(ctx context.Context, rsp *protos.RspDownloadSlice, conn core.WriteCloser) {
 	dataLen := uint64(len(rsp.Data))
 	utils.DebugLog("dataLen=========", dataLen)
 	dataStart := uint64(0)
@@ -75,15 +76,15 @@ func splitSendDownloadSliceData(rsp *protos.RspDownloadSlice, conn core.WriteClo
 		utils.DebugLog("_____________________________")
 		utils.DebugLog(dataStart, dataEnd, offsetStart, offsetEnd)
 		if dataEnd < dataLen {
-			peers.SendResponseMessageWithReqId(conn, requests.RspDownloadSliceDataSplit(rsp, dataStart, dataEnd, offsetStart, offsetEnd,
-				rsp.SliceInfo.SliceOffset.SliceOffsetStart, rsp.SliceInfo.SliceOffset.SliceOffsetEnd, false), header.RspDownloadSlice, reqId)
+			peers.SendMessage(ctx, conn, requests.RspDownloadSliceDataSplit(rsp, dataStart, dataEnd, offsetStart, offsetEnd,
+				rsp.SliceInfo.SliceOffset.SliceOffsetStart, rsp.SliceInfo.SliceOffset.SliceOffsetEnd, false), header.RspDownloadSlice)
 			dataStart += setting.MAXDATA
 			dataEnd += setting.MAXDATA
 			offsetStart += setting.MAXDATA
 			offsetEnd += setting.MAXDATA
 		} else {
-			peers.SendResponseMessageWithReqId(conn, requests.RspDownloadSliceDataSplit(rsp, dataStart, 0, offsetStart, 0,
-			rsp.SliceInfo.SliceOffset.SliceOffsetStart, rsp.SliceInfo.SliceOffset.SliceOffsetEnd, true), header.RspDownloadSlice, reqId)
+			peers.SendMessage(ctx, conn, requests.RspDownloadSliceDataSplit(rsp, dataStart, 0, offsetStart, 0,
+				rsp.SliceInfo.SliceOffset.SliceOffsetStart, rsp.SliceInfo.SliceOffset.SliceOffsetEnd, true), header.RspDownloadSlice)
 			return
 		}
 	}
@@ -91,7 +92,7 @@ func splitSendDownloadSliceData(rsp *protos.RspDownloadSlice, conn core.WriteClo
 
 // RspDownloadSlice storagePP-PP
 func RspDownloadSlice(ctx context.Context, conn core.WriteCloser) {
-	utils.DebugLog("get RspDownloadSlice")
+	pp.DebugLog(ctx, "get RspDownloadSlice")
 	var target protos.RspDownloadSlice
 	if !requests.UnmarshalData(ctx, &target) {
 		return
@@ -104,70 +105,72 @@ func RspDownloadSlice(ctx context.Context, conn core.WriteCloser) {
 
 	dTask, ok := task.GetDownloadTask(target.FileHash, target.WalletAddress, sid.(string))
 	if !ok {
-		utils.DebugLog("current task is stopped！！！！！！！！！！！！！！！！！！！！！！！！！！")
+		pp.DebugLog(ctx, "current task is stopped！！！！！！！！！！！！！！！！！！！！！！！！！！")
 		return
 	}
 
 	if target.SliceSize <= 0 || (target.Result.State == protos.ResultState_RES_FAIL && target.Result.Msg == LOSE_SLICE_MSG) {
-		utils.DebugLog("slice was not found, will send msg to sp for retry, sliceHash: ", target.SliceInfo.SliceHash)
-		setDownloadSliceFail(target.SliceInfo.SliceHash, target.TaskId, target.IsVideoCaching, dTask)
+		pp.DebugLog(ctx, "slice was not found, will send msg to sp for retry, sliceHash: ", target.SliceInfo.SliceHash)
+		setDownloadSliceFail(ctx, target.SliceInfo.SliceHash, target.TaskId, target.IsVideoCaching, dTask)
 		return
 	}
 
 	if target.Result.State == protos.ResultState_RES_FAIL {
-		utils.ErrorLog(target.Result.Msg)
+		pp.ErrorLog(ctx, target.Result.Msg)
 		return
 	}
 
-	if f, ok := task.DownloadFileMap.Load(target.FileHash+sid.(string)); ok {
+	if f, ok := task.DownloadFileMap.Load(target.FileHash + sid.(string)); ok {
 		fInfo := f.(*protos.RspFileStorageInfo)
-		utils.DebugLog("get a slice -------")
-		utils.DebugLog("SliceHash", target.SliceInfo.SliceHash)
-		utils.DebugLog("SliceOffset", target.SliceInfo.SliceOffset)
-		utils.DebugLog("length", len(target.Data))
-		utils.DebugLog("sliceSize", target.SliceSize)
+		pp.DebugLog(ctx, "get a slice -------")
+		pp.DebugLog(ctx, "SliceHash", target.SliceInfo.SliceHash)
+		pp.DebugLog(ctx, "SliceOffset", target.SliceInfo.SliceOffset)
+		pp.DebugLog(ctx, "length", len(target.Data))
+		pp.DebugLog(ctx, "sliceSize", target.SliceSize)
 		if fInfo.EncryptionTag != "" {
-			receiveSliceAndProgressEncrypted(&target, fInfo, dTask)
+			receiveSliceAndProgressEncrypted(ctx, &target, fInfo, dTask)
 		} else {
-			receiveSliceAndProgress(&target, fInfo, dTask)
+			receiveSliceAndProgress(ctx, &target, fInfo, dTask)
 		}
 		if !fInfo.IsVideoStream {
-			task.DownloadProgress(target.FileHash, sid.(string), uint64(len(target.Data)))
+			task.DownloadProgress(ctx, target.FileHash, sid.(string), uint64(len(target.Data)))
 		}
 	} else {
-		utils.DebugLog("DownloadFileMap doesn't have entry with file hash", target.FileHash);
+		utils.DebugLog("DownloadFileMap doesn't have entry with file hash", target.FileHash)
 	}
 }
 
-func receiveSliceAndProgress(target *protos.RspDownloadSlice, fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) {
-	if task.SaveDownloadFile(target, fInfo) {
+func receiveSliceAndProgress(ctx context.Context, target *protos.RspDownloadSlice, fInfo *protos.RspFileStorageInfo,
+	dTask *task.DownloadTask) {
+	if task.SaveDownloadFile(ctx, target, fInfo) {
 		dataLen := uint64(len(target.Data))
 		if s, ok := task.DownloadSliceProgress.Load(target.SliceInfo.SliceHash + fInfo.ReqId); ok {
 			alreadySize := s.(uint64)
 			alreadySize += dataLen
 			if alreadySize == target.SliceSize {
-				utils.DebugLog("slice download finished", target.SliceInfo.SliceHash)
+				pp.DebugLog(ctx, "slice download finished", target.SliceInfo.SliceHash)
 				task.DownloadSliceProgress.Delete(target.SliceInfo.SliceHash + fInfo.ReqId)
-				receivedSlice(target, fInfo, dTask)
+				receivedSlice(ctx, target, fInfo, dTask)
 			} else {
-				task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash + fInfo.ReqId, alreadySize)
+				task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash+fInfo.ReqId, alreadySize)
 			}
 		} else {
 			// if data is sent at once
 			if target.SliceSize == dataLen {
-				receivedSlice(target, fInfo, dTask)
+				receivedSlice(ctx, target, fInfo, dTask)
 			} else {
-				task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash + fInfo.ReqId, dataLen)
+				task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash+fInfo.ReqId, dataLen)
 			}
 		}
-	}else {
+	} else {
 		utils.DebugLog("Download failed: not able to write to the target file.")
 		file.CloseDownloadSession(fInfo.FileHash + fInfo.ReqId)
 		task.CleanDownloadFileAndConnMap(fInfo.FileHash, fInfo.ReqId)
 	}
 }
 
-func receiveSliceAndProgressEncrypted(target *protos.RspDownloadSlice, fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) {
+func receiveSliceAndProgressEncrypted(ctx context.Context, target *protos.RspDownloadSlice,
+	fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) {
 	dataToDecrypt := target.Data
 	dataToDecryptSize := uint64(len(dataToDecrypt))
 	encryptedOffset := target.SliceInfo.EncryptedSliceOffset
@@ -187,16 +190,16 @@ func receiveSliceAndProgressEncrypted(target *protos.RspDownloadSlice, fInfo *pr
 		// Decrypt slice data and save it to file
 		decryptedData, err := decryptSliceData(dataToDecrypt)
 		if err != nil {
-			utils.ErrorLog("Couldn't decrypt slice", err)
+			pp.ErrorLog(ctx, "Couldn't decrypt slice", err)
 			return
 		}
 		target.Data = decryptedData
 
-		if task.SaveDownloadFile(target, fInfo) {
-			utils.DebugLog("slice download finished", target.SliceInfo.SliceHash)
+		if task.SaveDownloadFile(ctx, target, fInfo) {
+			pp.DebugLog(ctx, "slice download finished", target.SliceInfo.SliceHash)
 			task.DownloadSliceProgress.Delete(target.SliceInfo.SliceHash + fInfo.ReqId)
 			task.DownloadEncryptedSlices.Delete(target.SliceInfo.SliceHash + fInfo.ReqId)
-			receivedSlice(target, fInfo, dTask)
+			receivedSlice(ctx, target, fInfo, dTask)
 		}
 	} else {
 		// Store partial slice data to memory
@@ -205,14 +208,14 @@ func receiveSliceAndProgressEncrypted(target *protos.RspDownloadSlice, fInfo *pr
 			dataToStore = make([]byte, target.SliceSize)
 			copy(dataToStore[encryptedOffset.SliceOffsetStart:encryptedOffset.SliceOffsetEnd], dataToDecrypt)
 		}
-		task.DownloadEncryptedSlices.Store(target.SliceInfo.SliceHash + fInfo.ReqId, dataToStore)
-		task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash + fInfo.ReqId, dataToDecryptSize)
+		task.DownloadEncryptedSlices.Store(target.SliceInfo.SliceHash+fInfo.ReqId, dataToStore)
+		task.DownloadSliceProgress.Store(target.SliceInfo.SliceHash+fInfo.ReqId, dataToDecryptSize)
 	}
 }
 
-func receivedSlice(target *protos.RspDownloadSlice, fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) {
-	file.SaveDownloadProgress(target.SliceInfo.SliceHash, fInfo.FileName, target.FileHash, target.SavePath, fInfo.ReqId)
-	task.CleanDownloadTask(target.FileHash, target.SliceInfo.SliceHash, target.WalletAddress, fInfo.ReqId)
+func receivedSlice(ctx context.Context, target *protos.RspDownloadSlice, fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) {
+	file.SaveDownloadProgress(ctx, target.SliceInfo.SliceHash, fInfo.FileName, target.FileHash, target.SavePath, fInfo.ReqId)
+	task.CleanDownloadTask(ctx, target.FileHash, target.SliceInfo.SliceHash, target.WalletAddress, fInfo.ReqId)
 	target.Result = &protos.Result{
 		State: protos.ResultState_RES_SUCCESS,
 	}
@@ -221,8 +224,8 @@ func receivedSlice(target *protos.RspDownloadSlice, fInfo *protos.RspFileStorage
 	} else if fInfo.IsVideoStream && target.IsVideoCaching {
 		videoCacheKeep(fInfo.FileHash, target.TaskId)
 	}
-	setDownloadSliceSuccess(target.SliceInfo.SliceHash, dTask)
-	SendReportDownloadResult(target, false)
+	setDownloadSliceSuccess(ctx, target.SliceInfo.SliceHash, dTask)
+	SendReportDownloadResult(ctx, target, false)
 }
 
 func videoCacheKeep(fileHash, taskID string) {
@@ -234,72 +237,72 @@ func videoCacheKeep(fileHash, taskID string) {
 }
 
 // ReportDownloadResult  PP-SP OR StoragePP-SP
-func SendReportDownloadResult(target *protos.RspDownloadSlice, isPP bool) {
-	utils.DebugLog("ReportDownloadResult report result target.fileHash = ", target.FileHash)
-	peers.SendMessageDirectToSPOrViaPP(requests.ReqReportDownloadResultData(target, isPP), header.ReqReportDownloadResult)
+func SendReportDownloadResult(ctx context.Context, target *protos.RspDownloadSlice, isPP bool) {
+	pp.DebugLog(ctx, "ReportDownloadResult report result target.fileHash = ", target.FileHash)
+	peers.SendMessageDirectToSPOrViaPP(ctx, requests.ReqReportDownloadResultData(target, isPP), header.ReqReportDownloadResult)
 }
 
 // ReportDownloadResult  P-SP OR PP-SP
 func SendReportStreamingResult(target *protos.RspDownloadSlice, isPP bool) {
-	peers.SendMessageToSPServer(requests.ReqReportDownloadResultData(target, isPP), header.ReqReportDownloadResult)
+	peers.SendMessageToSPServer(context.Background(), requests.ReqReportDownloadResultData(target, isPP), header.ReqReportDownloadResult)
 }
 
 // DownloadFileSlice
-func DownloadFileSlice(target *protos.RspFileStorageInfo) {
+func DownloadFileSlice(ctx context.Context, target *protos.RspFileStorageInfo) {
 	fileSize := uint64(0)
 
 	dTask, _ := task.GetDownloadTask(target.FileHash, target.WalletAddress, target.ReqId)
 	for _, sliceInfo := range target.SliceInfo {
 		fileSize += sliceInfo.SliceStorageInfo.SliceSize
 	}
-	utils.DebugLog(fmt.Sprintf("file size: %v  raw file size: %v\n", fileSize, target.FileSize))
+	pp.DebugLog(ctx, fmt.Sprintf("file size: %v  raw file size: %v\n", fileSize, target.FileSize))
 
 	sp := &task.DownloadSP{
 		RawSize:        int64(target.FileSize),
 		TotalSize:      int64(fileSize),
 		DownloadedSize: 0,
 	}
-	if !file.CheckFileExisting(target.FileHash, target.FileName, target.SavePath, target.EncryptionTag, target.ReqId) {
-		task.DownloadSpeedOfProgress.Store(target.FileHash + target.ReqId, sp)
+	if !file.CheckFileExisting(ctx, target.FileHash, target.FileName, target.SavePath, target.EncryptionTag, target.ReqId) {
+		task.DownloadSpeedOfProgress.Store(target.FileHash+target.ReqId, sp)
 		for _, rsp := range target.SliceInfo {
-			utils.DebugLog("taskid ======= ", rsp.TaskId)
+			pp.DebugLog(ctx, "taskid ======= ", rsp.TaskId)
 			if file.CheckSliceExisting(target.FileHash, target.FileName, rsp.SliceStorageInfo.SliceHash, target.SavePath, target.ReqId) {
-				utils.Log("slice exist already,", rsp.SliceStorageInfo.SliceHash)
-				task.DownloadProgress(target.FileHash, target.ReqId, rsp.SliceStorageInfo.SliceSize)
-				task.CleanDownloadTask(target.FileHash, rsp.SliceStorageInfo.SliceHash, target.WalletAddress, target.ReqId)
-				setDownloadSliceSuccess(rsp.SliceStorageInfo.SliceHash, dTask)
+				pp.Log(ctx, "slice exist already,", rsp.SliceStorageInfo.SliceHash)
+				task.DownloadProgress(ctx, target.FileHash, target.ReqId, rsp.SliceStorageInfo.SliceSize)
+				task.CleanDownloadTask(ctx, target.FileHash, rsp.SliceStorageInfo.SliceHash, target.WalletAddress, target.ReqId)
+				setDownloadSliceSuccess(ctx, rsp.SliceStorageInfo.SliceHash, dTask)
 			} else {
-				utils.DebugLog("request download data")
+				pp.DebugLog(ctx, "request download data")
 				req := requests.ReqDownloadSliceData(target, rsp)
 				task.SliceSessionMap.Store(req.ReqId, target.ReqId)
-				SendReqDownloadSlice(target.FileHash, rsp, req, target.ReqId)
+				SendReqDownloadSlice(ctx, target.FileHash, rsp, req, target.ReqId)
 			}
 		}
-  	} else {
+	} else {
 		utils.ErrorLog("file exists already!")
 		task.DeleteDownloadTask(target.FileHash, target.WalletAddress, target.ReqId)
 	}
 }
 
-func SendReqDownloadSlice(fileHash string, sliceInfo *protos.DownloadSliceInfo, req *protos.ReqDownloadSlice, fileReqId string) {
-	utils.DebugLog("req = ", req)
+func SendReqDownloadSlice(ctx context.Context, fileHash string, sliceInfo *protos.DownloadSliceInfo, req *protos.ReqDownloadSlice, fileReqId string) {
+	pp.DebugLog(ctx, "req = ", req)
 
 	networkAddress := sliceInfo.StoragePpInfo.NetworkAddress
 	key := fileHash + sliceInfo.StoragePpInfo.P2PAddress + fileReqId
 
 	if c, ok := client.DownloadConnMap.Load(key); ok {
 		conn := c.(*cf.ClientConn)
-		err := peers.SendMessage(conn, req, header.ReqDownloadSlice)
+		err := peers.SendMessage(ctx, conn, req, header.ReqDownloadSlice)
 		if err == nil {
-			utils.DebugLog("Send download slice request to ", networkAddress)
+			pp.DebugLog(ctx, "Send download slice request to ", networkAddress)
 			return
 		}
 	}
 
 	if conn, ok := client.ConnMap[networkAddress]; ok {
-		err := peers.SendMessage(conn, req, header.ReqDownloadSlice)
+		err := peers.SendMessage(ctx, conn, req, header.ReqDownloadSlice)
 		if err == nil {
-			utils.DebugLog("Send download slice request to ", networkAddress)
+			pp.DebugLog(ctx, "Send download slice request to ", networkAddress)
 			client.DownloadConnMap.Store(key, conn)
 			return
 		}
@@ -307,28 +310,28 @@ func SendReqDownloadSlice(fileHash string, sliceInfo *protos.DownloadSliceInfo, 
 
 	conn := client.NewClient(networkAddress, false)
 	if conn == nil {
-		utils.ErrorLog("Fail to create connection with " + networkAddress)
+		pp.ErrorLog(ctx, "Fail to create connection with "+networkAddress)
 		if dTask, ok := task.GetDownloadTask(fileHash, req.WalletAddress, fileReqId); ok {
-			setDownloadSliceFail(sliceInfo.SliceStorageInfo.SliceHash, req.TaskId, req.IsVideoCaching, dTask)
+			setDownloadSliceFail(ctx, sliceInfo.SliceStorageInfo.SliceHash, req.TaskId, req.IsVideoCaching, dTask)
 		}
 		return
 	}
 
-	err := peers.SendMessage(conn, req, header.ReqDownloadSlice)
+	err := peers.SendMessage(ctx, conn, req, header.ReqDownloadSlice)
 	if err == nil {
-		utils.DebugLog("Send download slice request to ", networkAddress)
+		pp.DebugLog(ctx, "Send download slice request to ", networkAddress)
 		client.DownloadConnMap.Store(key, conn)
 	} else {
-		utils.ErrorLog("Fail to send download slice request to" + networkAddress)
+		pp.ErrorLog(ctx, "Fail to send download slice request to"+networkAddress)
 	}
 }
 
 // RspReportDownloadResult  SP-P OR SP-PP
 func RspReportDownloadResult(ctx context.Context, conn core.WriteCloser) {
-	utils.DebugLog("get RspReportDownloadResult")
+	pp.DebugLog(ctx, "get RspReportDownloadResult")
 	var target protos.RspReportDownloadResult
 	if requests.UnmarshalData(ctx, &target) {
-		utils.DebugLog("result", target.Result.State, target.Result.Msg)
+		pp.DebugLog(ctx, "result", target.Result.State, target.Result.Msg)
 	}
 }
 
@@ -345,7 +348,7 @@ func RspDownloadSliceWrong(ctx context.Context, conn core.WriteCloser) {
 					sInfo.StoragePpInfo.P2PAddress = target.NewSliceInfo.StoragePpInfo.P2PAddress
 					sInfo.StoragePpInfo.WalletAddress = target.NewSliceInfo.StoragePpInfo.WalletAddress
 					sInfo.StoragePpInfo.NetworkAddress = target.NewSliceInfo.StoragePpInfo.NetworkAddress
-					peers.TransferSendMessageToPPServ(target.NewSliceInfo.StoragePpInfo.NetworkAddress, requests.RspDownloadSliceWrong(&target))
+					peers.TransferSendMessageToPPServ(ctx, target.NewSliceInfo.StoragePpInfo.NetworkAddress, requests.RspDownloadSliceWrong(&target))
 				}
 			}
 		}
@@ -354,7 +357,7 @@ func RspDownloadSliceWrong(ctx context.Context, conn core.WriteCloser) {
 
 func downloadWrong(taskID, sliceHash, p2pAddress, walletAddress string, wrongType protos.DownloadWrongType) {
 	utils.DebugLog("downloadWrong, sliceHash: ", sliceHash)
-	peers.SendMessageToSPServer(requests.ReqDownloadSliceWrong(taskID, sliceHash, p2pAddress, walletAddress, wrongType), header.ReqDownloadSliceWrong)
+	peers.SendMessageToSPServer(context.Background(), requests.ReqDownloadSliceWrong(taskID, sliceHash, p2pAddress, walletAddress, wrongType), header.ReqDownloadSliceWrong)
 }
 
 // DownloadSlicePause
@@ -405,15 +408,15 @@ func verifyDownloadSliceSign(target *protos.ReqDownloadSlice, rsp *protos.RspDow
 	return target.SliceInfo.SliceHash == utils.CalcSliceHash(rsp.Data, target.FileHash, target.SliceNumber)
 }
 
-func setDownloadSliceSuccess(sliceHash string, dTask *task.DownloadTask) {
+func setDownloadSliceSuccess(ctx context.Context, sliceHash string, dTask *task.DownloadTask) {
 	dTask.SetSliceSuccess(sliceHash)
-	CheckAndSendRetryMessage(dTask)
+	CheckAndSendRetryMessage(ctx, dTask)
 }
 
-func setDownloadSliceFail(sliceHash, taskId string, isVideoCaching bool, dTask *task.DownloadTask) {
+func setDownloadSliceFail(ctx context.Context, sliceHash, taskId string, isVideoCaching bool, dTask *task.DownloadTask) {
 	dTask.AddFailedSlice(sliceHash)
 	if isVideoCaching {
 		videoCacheKeep(dTask.FileHash, taskId)
 	}
-	CheckAndSendRetryMessage(dTask)
+	CheckAndSendRetryMessage(ctx, dTask)
 }

--- a/pp/event/get_pp_status.go
+++ b/pp/event/get_pp_status.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
 	"github.com/stratosnet/sds/pp/setting"
@@ -20,13 +21,13 @@ func RspGetPPStatus(ctx context.Context, conn core.WriteCloser) {
 	if !requests.UnmarshalData(ctx, &target) {
 		return
 	}
-	utils.DebugLogf("get GetPPStatus RSP, activation status = %v", target.IsActive)
+	pp.DebugLogf(ctx, "get GetPPStatus RSP, activation status = %v", target.IsActive)
 	if target.Result.State != protos.ResultState_RES_SUCCESS {
 		utils.ErrorLog(target.Result.Msg)
 		if strings.Contains(target.Result.Msg, "Please register first") {
 			return
 		}
-		utils.Log("failed to query node status, please retry later")
+		pp.Log(ctx, "failed to query node status, please retry later")
 		return
 	}
 
@@ -35,14 +36,14 @@ func RspGetPPStatus(ctx context.Context, conn core.WriteCloser) {
 		setting.IsPP = true
 	}
 
-	formatRspGetPPStatus(target)
+	formatRspGetPPStatus(ctx, target)
 
 	if target.InitPpList {
-		peers.InitPPList()
+		peers.InitPPList(ctx)
 	}
 }
 
-func formatRspGetPPStatus(response protos.RspGetPPStatus) {
+func formatRspGetPPStatus(ctx context.Context, response protos.RspGetPPStatus) {
 	activation, state := "", ""
 
 	switch response.IsActive {
@@ -71,7 +72,7 @@ func formatRspGetPPStatus(response protos.RspGetPPStatus) {
 	default:
 		state = "Unknown"
 	}
-	utils.Logf("*** current node status ***\n"+
+	pp.Logf(ctx, "*** current node status ***\n"+
 		"Activation: %v | Mining: %v | Initial tier: %v | Ongoing tier: %v | Weight score: %v",
 		activation, state, response.InitTier, response.OngoingTier, response.WeightScore)
 }

--- a/pp/event/get_pplist.go
+++ b/pp/event/get_pplist.go
@@ -25,7 +25,7 @@ func RspGetPPList(ctx context.Context, conn core.WriteCloser) {
 		return
 	}
 
-	err := peers.SavePPList(&target)
+	err := peers.SavePPList(ctx, &target)
 	if err != nil {
 		utils.ErrorLog("Error when saving PP List", err)
 	}
@@ -34,6 +34,6 @@ func RspGetPPList(ctx context.Context, conn core.WriteCloser) {
 		(setting.State == types.PP_ACTIVE)
 
 	if shouldRegisterToSP {
-		peers.RegisterToSP(true)
+		peers.RegisterToSP(ctx, true)
 	}
 }

--- a/pp/event/get_splist.go
+++ b/pp/event/get_splist.go
@@ -22,7 +22,7 @@ func RspGetSPList(ctx context.Context, conn core.WriteCloser) {
 	utils.DebugLog("get GetSPList RSP", target.SpList)
 	if target.Result.State != protos.ResultState_RES_SUCCESS {
 		utils.Log("failed to get any indexing nodes, reloading")
-		peers.ScheduleReloadSPlist(time.Second * 3)
+		peers.ScheduleReloadSPlist(ctx, time.Second*3)
 		return
 	}
 

--- a/pp/event/get_wallet_oz.go
+++ b/pp/event/get_wallet_oz.go
@@ -6,39 +6,39 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/api/rpc"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
-	"github.com/stratosnet/sds/utils"
 )
 
 // GetWalletOz queries current ozone balance
-func GetWalletOz(walletAddr, reqId string) error {
-	utils.Logf("Querying current ozone balance of the wallet: %v", walletAddr)
-	peers.SendMessageToSPServer(requests.ReqGetWalletOzData(walletAddr, reqId), header.ReqGetWalletOz)
+func GetWalletOz(ctx context.Context, walletAddr, reqId string) error {
+	pp.Logf(ctx, "Querying current ozone balance of the wallet: %v", walletAddr)
+	peers.SendMessageToSPServer(ctx, requests.ReqGetWalletOzData(walletAddr, reqId), header.ReqGetWalletOz)
 	return nil
 }
 
 func RspGetWalletOz(ctx context.Context, conn core.WriteCloser) {
-	utils.DebugLog("get GetWalletOz RSP")
+	pp.DebugLog(ctx, "get GetWalletOz RSP")
 	var target protos.RspGetWalletOz
 	if !requests.UnmarshalData(ctx, &target) {
-		utils.DebugLog("Cannot unmarshal ozone balance data")
+		pp.DebugLog(ctx, "Cannot unmarshal ozone balance data")
 		return
 	}
 
 	rpcResult := &rpc.GetOzoneResult{}
 	if target.ReqId != "" {
-		defer file.SetQueryOzoneResult(target.WalletAddress + target.ReqId, rpcResult)
+		defer file.SetQueryOzoneResult(target.WalletAddress+target.ReqId, rpcResult)
 	}
 
 	if target.Result.State != protos.ResultState_RES_SUCCESS {
-		utils.Logf("failed to get ozone balance: %v", target.Result.Msg)
+		pp.Logf(ctx, "failed to get ozone balance: %v", target.Result.Msg)
 		rpcResult.Return = rpc.INTERNAL_COMM_FAILURE
 		return
 	}
-	utils.Logf("get GetWalletOz RSP, the current ozone balance of %v = %v, %v", target.GetWalletAddress(), target.GetWalletOz(), target.ReqId)
+	pp.Logf(ctx, "get GetWalletOz RSP, the current ozone balance of %v = %v, %v", target.GetWalletAddress(), target.GetWalletOz(), target.ReqId)
 	rpcResult.Return = rpc.SUCCESS
 	rpcResult.Ozone = target.WalletOz
 	return

--- a/pp/event/prepay.go
+++ b/pp/event/prepay.go
@@ -6,21 +6,21 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
 	"github.com/stratosnet/sds/relay/stratoschain"
-	"github.com/stratosnet/sds/utils"
 )
 
 // Prepay PP node sends a prepay transaction
-func Prepay(amount, fee, gas int64) error {
+func Prepay(ctx context.Context, amount, fee, gas int64) error {
 	prepayReq, err := reqPrepayData(amount, fee, gas)
 	if err != nil {
-		utils.ErrorLog("Couldn't build PP prepay request: " + err.Error())
+		pp.ErrorLog(ctx, "Couldn't build PP prepay request: "+err.Error())
 		return err
 	}
-	utils.Log("Sending prepay message to SP! " + prepayReq.WalletAddress)
-	peers.SendMessageToSPServer(prepayReq, header.ReqPrepay)
+	pp.Log(ctx, "Sending prepay message to SP! "+prepayReq.WalletAddress)
+	peers.SendMessageToSPServer(ctx, prepayReq, header.ReqPrepay)
 	return nil
 }
 
@@ -32,20 +32,20 @@ func RspPrepay(ctx context.Context, conn core.WriteCloser) {
 		return
 	}
 
-	utils.Log("get RspPrepay", target.Result.State, target.Result.Msg)
+	pp.Log(ctx, "get RspPrepay", target.Result.State, target.Result.Msg)
 	if target.Result.State != protos.ResultState_RES_SUCCESS {
 		return
 	}
 
 	err := stratoschain.BroadcastTxBytes(target.Tx)
 	if err != nil {
-		utils.ErrorLog("The prepay transaction couldn't be broadcast", err)
+		pp.ErrorLog(ctx, "The prepay transaction couldn't be broadcast", err)
 	} else {
-		utils.Log("The prepay transaction was broadcast")
+		pp.Log(ctx, "The prepay transaction was broadcast")
 	}
 }
 
 // RspPrepaid. Response when this PP node's prepay transaction was successful
 func RspPrepaid(ctx context.Context, conn core.WriteCloser) {
-	utils.Log("The prepay transaction has been executed")
+	pp.Log(ctx, "The prepay transaction has been executed")
 }

--- a/pp/event/query_file_info.go
+++ b/pp/event/query_file_info.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/api/rpc"
 	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/file"
@@ -23,21 +24,21 @@ import (
 )
 
 // GetFileStorageInfo p to pp
-func GetFileStorageInfo(path, savePath, reqID, walletAddr, saveAs string, isVideoStream bool, w http.ResponseWriter) {
+func GetFileStorageInfo(ctx context.Context, path, savePath, reqID, walletAddr, saveAs string, isVideoStream bool, w http.ResponseWriter) {
 	if !setting.CheckLogin() {
 		notLogin(w)
 		return
 	}
 
 	if !CheckDownloadPath(path) {
-		utils.ErrorLog("please input correct download link, eg: sdm://address/fileHash|filename(optional)")
+		pp.ErrorLog(ctx, "please input correct download link, eg: sdm://address/fileHash|filename(optional)")
 		if w != nil {
 			w.Write(httpserv.NewJson(nil, setting.FAILCode, "please input correct download link, eg:  sdm://address/fileHash|filename(optional)").ToBytes())
 		}
 		return
 	}
 
-	utils.DebugLog("path:", path)
+	pp.DebugLog(ctx, "path:", path)
 	walletAddress := path[6:47]
 	fileHash := path[48:88]
 
@@ -51,7 +52,7 @@ func GetFileStorageInfo(path, savePath, reqID, walletAddr, saveAs string, isVide
 	}
 
 	req := requests.ReqFileStorageInfoData(path, savePath, reqID, walletAddr, saveAs, isVideoStream, nil)
-	peers.SendMessageDirectToSPOrViaPP(req, header.ReqFileStorageInfo)
+	peers.SendMessageDirectToSPOrViaPP(ctx, req, header.ReqFileStorageInfo)
 }
 
 func ClearFileInfoAndDownloadTask(fileHash string, fileReqId string, w http.ResponseWriter) {
@@ -63,7 +64,7 @@ func ClearFileInfoAndDownloadTask(fileHash string, fileReqId string, w http.Resp
 			FileHash:      fileHash,
 			P2PAddress:    setting.P2PAddress,
 		}
-		peers.SendMessage(client.PPConn, req, header.ReqClearDownloadTask)
+		peers.SendMessage(context.Background(), client.PPConn, req, header.ReqClearDownloadTask)
 		w.Write([]byte("ok"))
 	} else {
 		notLogin(w)
@@ -97,7 +98,7 @@ func GetVideoSlice(sliceInfo *protos.DownloadSliceInfo, fInfo *protos.RspFileSto
 		} else {
 			req := requests.ReqDownloadSliceData(fInfo, sliceInfo)
 			utils.Log("Send request for downloading slice: ", sliceInfo.SliceStorageInfo.SliceHash)
-			SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
+			SendReqDownloadSlice(nil, fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
 			if err := storeResponseWriter(req.ReqId, w); err != nil {
 				w.WriteHeader(setting.FAILCode)
 				w.Write(httpserv.NewErrorJson(setting.FAILCode, "Get video segment time out").ToBytes())
@@ -108,7 +109,7 @@ func GetVideoSlice(sliceInfo *protos.DownloadSliceInfo, fInfo *protos.RspFileSto
 	}
 }
 
-func GetVideoSlices(fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) {
+func GetVideoSlices(ctx context.Context, fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) {
 	slices := make([]*protos.DownloadSliceInfo, len(fInfo.SliceInfo))
 
 	// reverse order to download start from last slice
@@ -126,7 +127,7 @@ func GetVideoSlices(fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) 
 	task.VideoCacheTaskMap.Store(fInfo.FileHash, videoCacheTask)
 
 	if len(videoCacheTask.Slices) > setting.STREAM_CACHE_MAXSLICE {
-		go cacheSlice(videoCacheTask, fInfo, dTask)
+		go cacheSlice(ctx, videoCacheTask, fInfo, dTask)
 		for i := 0; i < setting.STREAM_CACHE_MAXSLICE; i++ {
 			videoCacheTask.DownloadCh <- true
 		}
@@ -137,11 +138,11 @@ func GetVideoSlices(fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) 
 				req := requests.ReqDownloadSliceData(fInfo, sliceInfo)
 				req.IsVideoCaching = true
 				if req != nil {
-					SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
+					SendReqDownloadSlice(nil, fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
 				}
 			} else {
-				task.CleanDownloadTask(fInfo.FileHash, sliceInfo.SliceStorageInfo.SliceHash, setting.WalletAddress, task.LOCAL_REQID)
-				setDownloadSliceSuccess(sliceInfo.SliceStorageInfo.SliceHash, dTask)
+				task.CleanDownloadTask(ctx, fInfo.FileHash, sliceInfo.SliceStorageInfo.SliceHash, setting.WalletAddress, task.LOCAL_REQID)
+				setDownloadSliceSuccess(ctx, sliceInfo.SliceStorageInfo.SliceHash, dTask)
 			}
 		}
 		utils.DebugLog("all slices of the task have begun downloading")
@@ -153,7 +154,7 @@ func GetVideoSlices(fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) 
 	}
 }
 
-func cacheSlice(videoCacheTask *task.VideoCacheTask, fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) {
+func cacheSlice(ctx context.Context, videoCacheTask *task.VideoCacheTask, fInfo *protos.RspFileStorageInfo, dTask *task.DownloadTask) {
 	for {
 		select {
 		case goon := <-videoCacheTask.DownloadCh:
@@ -173,13 +174,13 @@ func cacheSlice(videoCacheTask *task.VideoCacheTask, fInfo *protos.RspFileStorag
 			utils.DebugLog("start Download!!!!!", sliceInfo.SliceNumber)
 			if file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceInfo.SliceStorageInfo.SliceHash, fInfo.SavePath, fInfo.ReqId) {
 				utils.DebugLog("slice exist already ", sliceInfo.SliceNumber)
-				task.CleanDownloadTask(fInfo.FileHash, sliceInfo.SliceStorageInfo.SliceHash, setting.WalletAddress, task.LOCAL_REQID)
-				setDownloadSliceSuccess(sliceInfo.SliceStorageInfo.SliceHash, dTask)
+				task.CleanDownloadTask(ctx, fInfo.FileHash, sliceInfo.SliceStorageInfo.SliceHash, setting.WalletAddress, task.LOCAL_REQID)
+				setDownloadSliceSuccess(ctx, sliceInfo.SliceStorageInfo.SliceHash, dTask)
 				videoCacheTask.DownloadCh <- true
 			} else {
 				req := requests.ReqDownloadSliceData(fInfo, sliceInfo)
 				req.IsVideoCaching = true
-				SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
+				SendReqDownloadSlice(nil, fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
 			}
 
 			videoCacheTask.Slices = append(videoCacheTask.Slices[:0], videoCacheTask.Slices[0+1:]...)
@@ -192,7 +193,7 @@ func GetHlsInfo(fInfo *protos.RspFileStorageInfo) *file.HlsInfo {
 	sliceHash := sliceInfo.SliceStorageInfo.SliceHash
 	if !file.CheckSliceExisting(fInfo.FileHash, fInfo.FileName, sliceHash, fInfo.SavePath, fInfo.ReqId) {
 		req := requests.ReqDownloadSliceData(fInfo, sliceInfo)
-		SendReqDownloadSlice(fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
+		SendReqDownloadSlice(nil, fInfo.FileHash, sliceInfo, req, fInfo.ReqId)
 
 		start := time.Now().Unix()
 		for {
@@ -224,29 +225,29 @@ func GetSliceInfoBySliceNumber(fInfo *protos.RspFileStorageInfo, sliceNumber uin
 // ReqFileStorageInfo  P-PP , PP-SP
 func ReqFileStorageInfo(ctx context.Context, conn core.WriteCloser) {
 	utils.Log("pp get ReqFileStorageInfo directly transfer to SP")
-	peers.TransferSendMessageToSPServer(core.MessageFromContext(ctx))
+	peers.TransferSendMessageToSPServer(ctx, core.MessageFromContext(ctx))
 }
 
 // RspFileStorageInfo SP-PP , PP-P
 func RspFileStorageInfo(ctx context.Context, conn core.WriteCloser) {
 	// PP check whether itself is the storage PP, if not transfer
-	utils.Log("get，RspFileStorageInfo")
+	pp.Log(ctx, "get，RspFileStorageInfo")
 	var target protos.RspFileStorageInfo
 	if requests.UnmarshalData(ctx, &target) {
-		utils.DebugLog("file hash, reqid:", target.FileHash, target.ReqId)
+		pp.DebugLog(ctx, "file hash, reqid:", target.FileHash, target.ReqId)
 		if target.Result.State == protos.ResultState_RES_SUCCESS {
-			utils.Log("download starts: ")
+			pp.Log(ctx, "download starts: ")
 			task.CleanDownloadFileAndConnMap(target.FileHash, target.ReqId)
 			task.DownloadFileMap.Store(target.FileHash+target.ReqId, &target)
 			task.AddDownloadTask(&target)
 			if target.IsVideoStream {
 				return
 			}
-			DownloadFileSlice(&target)
-			utils.DebugLog("DownloadFileSlice(&target)", target)
+			DownloadFileSlice(ctx, &target)
+			pp.DebugLog(ctx, "DownloadFileSlice(&target)", target)
 		} else {
 			file.SetRemoteFileResult(target.FileHash+target.ReqId, rpc.Result{Return: rpc.FILE_REQ_FAILURE})
-			utils.Log("failed to download，", target.Result.Msg)
+			pp.Log(ctx, "failed to download，", target.Result.Msg)
 		}
 	}
 }

--- a/pp/event/register_new_pp.go
+++ b/pp/event/register_new_pp.go
@@ -7,28 +7,28 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
 	"github.com/stratosnet/sds/pp/setting"
-	"github.com/stratosnet/sds/utils"
 )
 
 // RegisterNewPP P-SP P register to become PP
-func RegisterNewPP() {
+func RegisterNewPP(ctx context.Context) {
 	if setting.CheckLogin() {
-		peers.SendMessageToSPServer(requests.ReqRegisterNewPPData(), header.ReqRegisterNewPP)
+		peers.SendMessageToSPServer(ctx, requests.ReqRegisterNewPPData(), header.ReqRegisterNewPP)
 	}
 }
 
 // RspRegisterNewPP  SP-P
 func RspRegisterNewPP(ctx context.Context, conn core.WriteCloser) {
-	utils.Log("get RspRegisterNewPP")
+	pp.Log(ctx, "get RspRegisterNewPP")
 	var target protos.RspRegisterNewPP
 	if !requests.UnmarshalData(ctx, &target) {
 		return
 	}
 
-	utils.Log("get RspRegisterNewPP", target.Result.State, target.Result.Msg)
+	pp.Log(ctx, "get RspRegisterNewPP", target.Result.State, target.Result.Msg)
 	if target.Result.State != protos.ResultState_RES_SUCCESS {
 		if target.AlreadyPp {
 			setting.IsPP = true
@@ -36,6 +36,6 @@ func RspRegisterNewPP(ctx context.Context, conn core.WriteCloser) {
 		return
 	}
 
-	utils.Log("registered as PP successfully, you can deposit by `activate` ")
+	pp.Log(ctx, "registered as PP successfully, you can deposit by `activate` ")
 	setting.IsPP = true
 }

--- a/pp/event/register_to_sp.go
+++ b/pp/event/register_to_sp.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
@@ -18,7 +19,7 @@ import (
 func ReqRegister(ctx context.Context, conn core.WriteCloser) {
 	var target protos.ReqRegister
 	if requests.UnmarshalData(ctx, &target) {
-		peers.UpdatePP(&types.PeerInfo{
+		peers.UpdatePP(ctx, &types.PeerInfo{
 			NetworkAddress: target.Address.NetworkAddress,
 			P2pAddress:     target.Address.P2PAddress,
 			RestAddress:    target.Address.RestAddress,
@@ -26,7 +27,7 @@ func ReqRegister(ctx context.Context, conn core.WriteCloser) {
 			NetId:          core.NetIDFromContext(ctx),
 			Status:         types.PEER_CONNECTED,
 		})
-		peers.TransferSendMessageToSPServer(requests.ReqRegisterDataTR(&target))
+		peers.TransferSendMessageToSPServer(ctx, requests.ReqRegisterDataTR(&target))
 
 		// IPProt := strings.Split(target.Address.NetworkAddress, ":")
 		// ip := ""
@@ -55,68 +56,68 @@ func ReqRegister(ctx context.Context, conn core.WriteCloser) {
 
 // RspRegister  PP -> SP, SP -> PP, PP -> P
 func RspRegister(ctx context.Context, conn core.WriteCloser) {
-	utils.Log("get RspRegister", conn)
+	pp.Log(ctx, "get RspRegister", conn)
 	var target protos.RspRegister
 	if !requests.UnmarshalData(ctx, &target) {
 		return
 	}
-	utils.Log("target.RspRegister", target.P2PAddress)
+	pp.Log(ctx, "target.RspRegister", target.P2PAddress)
 	if target.P2PAddress != setting.P2PAddress {
-		utils.Log("transfer RspRegister to: ", target.P2PAddress)
-		peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
+		pp.Log(ctx, "transfer RspRegister to: ", target.P2PAddress)
+		peers.TransferSendMessageToPPServByP2pAddress(ctx, target.P2PAddress, core.MessageFromContext(ctx))
 		return
 	}
 
-	utils.Log("get RspRegister ", target.Result.State, target.Result.Msg)
+	pp.Log(ctx, "get RspRegister ", target.Result.State, target.Result.Msg)
 	if target.Result.State != protos.ResultState_RES_SUCCESS {
 		//setting.P2PAddress = ""
 		//setting.WalletAddress = ""
-		utils.Log("Register failed", target.Result.Msg)
+		pp.Log(ctx, "Register failed", target.Result.Msg)
 		return
 	}
 
-	utils.Log("Register successful", target.Result.Msg)
+	pp.Log(ctx, "Register successful", target.Result.Msg)
 	setting.IsLoad = true
 	setting.IsLoginToSP = true
-	utils.DebugLog("@@@@@@@@@@@@@@@@@@@@@@@@@@@@", client.GetConnectionName(conn))
+	pp.DebugLog(ctx, "@@@@@@@@@@@@@@@@@@@@@@@@@@@@", client.GetConnectionName(conn))
 	setting.IsPP = target.IsPP
 	if !setting.IsPP {
-		reportDHInfoToPP()
+		reportDHInfoToPP(ctx)
 	}
 	if setting.IsPP && !setting.IsStartMining {
-		peers.StartMining()
+		peers.StartMining(ctx)
 	}
 }
 
 // RspMining RspMining
 func RspMining(ctx context.Context, conn core.WriteCloser) {
-	utils.DebugLog("get RspMining", conn)
+	pp.DebugLog(ctx, "get RspMining", conn)
 	var target protos.RspMining
 	if !requests.UnmarshalData(ctx, &target) {
 		return
 	}
 
 	if target.Result.State != protos.ResultState_RES_SUCCESS {
-		utils.Log(target.Result.Msg)
+		pp.Log(ctx, target.Result.Msg)
 		return
 	}
 
-	utils.Log("start mining")
+	pp.Log(ctx, "start mining")
 	if peers.GetPPServer() == nil {
-		go peers.StartListenServer(setting.Config.Port)
+		go peers.StartListenServer(ctx, setting.Config.Port)
 	}
 	setting.IsStartMining = true
 
-	newConnection, err := peers.ConnectToSP()
+	newConnection, err := peers.ConnectToSP(ctx)
 	if err != nil {
 		utils.ErrorLog(err)
 		return
 	}
 	if newConnection {
-		peers.RegisterToSP(true)
+		peers.RegisterToSP(ctx, true)
 	}
 
-	utils.DebugLog("Start reporting node status to SP")
+	pp.DebugLog(ctx, "Start reporting node status to SP")
 	// trigger 1 stat report immediately
-	peers.ReportNodeStatus()
+	peers.ReportNodeStatus(ctx)()
 }

--- a/pp/event/share.go
+++ b/pp/event/share.go
@@ -7,20 +7,21 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/api/rpc"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/requests"
-	"github.com/stratosnet/sds/pp/task"
 	"github.com/stratosnet/sds/pp/setting"
+	"github.com/stratosnet/sds/pp/task"
 	"github.com/stratosnet/sds/utils"
 	"github.com/stratosnet/sds/utils/datamesh"
 )
 
 // GetAllShareLink GetShareLink
-func GetAllShareLink(reqID, walletAddr string, page uint64, w http.ResponseWriter) {
+func GetAllShareLink(ctx context.Context, reqID, walletAddr string, page uint64, w http.ResponseWriter) {
 	if setting.CheckLogin() {
-		peers.SendMessageDirectToSPOrViaPP(requests.ReqShareLinkData(reqID, walletAddr, page), header.ReqShareLink)
+		peers.SendMessageDirectToSPOrViaPP(ctx, requests.ReqShareLinkData(reqID, walletAddr, page), header.ReqShareLink)
 		storeResponseWriter(reqID, w)
 	} else {
 		notLogin(w)
@@ -28,9 +29,9 @@ func GetAllShareLink(reqID, walletAddr string, page uint64, w http.ResponseWrite
 }
 
 // GetReqShareFile GetReqShareFile
-func GetReqShareFile(reqID, fileHash, pathHash, walletAddr string, shareTime int64, isPrivate bool, w http.ResponseWriter) {
+func GetReqShareFile(ctx context.Context, reqID, fileHash, pathHash, walletAddr string, shareTime int64, isPrivate bool, w http.ResponseWriter) {
 	if setting.CheckLogin() {
-		peers.SendMessageDirectToSPOrViaPP(requests.ReqShareFileData(reqID, fileHash, pathHash, walletAddr, isPrivate, shareTime), header.ReqShareFile)
+		peers.SendMessageDirectToSPOrViaPP(ctx, requests.ReqShareFileData(reqID, fileHash, pathHash, walletAddr, isPrivate, shareTime), header.ReqShareFile)
 		storeResponseWriter(reqID, w)
 	} else {
 		notLogin(w)
@@ -38,9 +39,9 @@ func GetReqShareFile(reqID, fileHash, pathHash, walletAddr string, shareTime int
 }
 
 // DeleteShare DeleteShare
-func DeleteShare(shareID, reqID, walletAddress string, w http.ResponseWriter) {
+func DeleteShare(ctx context.Context, shareID, reqID, walletAddress string, w http.ResponseWriter) {
 	if setting.CheckLogin() {
-		peers.SendMessageDirectToSPOrViaPP(requests.ReqDeleteShareData(reqID, shareID, walletAddress), header.ReqDeleteShare)
+		peers.SendMessageDirectToSPOrViaPP(ctx, requests.ReqDeleteShareData(reqID, shareID, walletAddress), header.ReqDeleteShare)
 		storeResponseWriter(reqID, w)
 	} else {
 		notLogin(w)
@@ -51,12 +52,12 @@ func DeleteShare(shareID, reqID, walletAddress string, w http.ResponseWriter) {
 func ReqShareLink(ctx context.Context, conn core.WriteCloser) {
 	// pp send to SP
 	utils.DebugLog("ReqShareLinkReqShareLinkReqShareLinkReqShareLink")
-	peers.TransferSendMessageToSPServer(core.MessageFromContext(ctx))
+	peers.TransferSendMessageToSPServer(ctx, core.MessageFromContext(ctx))
 }
 
 // RspShareLink
 func RspShareLink(ctx context.Context, conn core.WriteCloser) {
-	utils.DebugLog("RspShareLink(ctx context.Context, conn core.WriteCloser) {RspShareLink(ctx context.Context, conn core.WriteCloser) {")
+	pp.DebugLog(ctx, "RspShareLink(ctx context.Context, conn core.WriteCloser) {RspShareLink(ctx context.Context, conn core.WriteCloser) {")
 	var target protos.RspShareLink
 	rpcResult := &rpc.FileShareResult{}
 
@@ -70,7 +71,7 @@ func RspShareLink(ctx context.Context, conn core.WriteCloser) {
 	}
 
 	if target.P2PAddress != setting.P2PAddress {
-		peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
+		peers.TransferSendMessageToPPServByP2pAddress(ctx, target.P2PAddress, core.MessageFromContext(ctx))
 		rpcResult.Return = rpc.WRONG_PP_ADDRESS
 		return
 	}
@@ -78,22 +79,22 @@ func RspShareLink(ctx context.Context, conn core.WriteCloser) {
 	if target.Result.State == protos.ResultState_RES_SUCCESS {
 		var fileInfos = make([]rpc.FileInfo, 0)
 		for _, info := range target.ShareInfo {
-			utils.Log("_______________________________")
-			utils.Log("file_name:", info.Name)
-			utils.Log("file_hash:", info.FileHash)
-			utils.Log("file_size:", info.FileSize)
-			utils.Log("link_time:", info.LinkTime)
-			utils.Log("link_time_exp:", info.LinkTimeExp)
-			utils.Log("ShareId:", info.ShareId)
-			utils.Log("ShareLink:", info.ShareLink)
-			fileInfos = append(fileInfos, rpc.FileInfo {
-				FileHash: info.FileHash,
-				FileSize: info.FileSize,
-				FileName: info.Name,
-				LinkTime: info.LinkTime,
+			pp.Log(ctx, "_______________________________")
+			pp.Log(ctx, "file_name:", info.Name)
+			pp.Log(ctx, "file_hash:", info.FileHash)
+			pp.Log(ctx, "file_size:", info.FileSize)
+			pp.Log(ctx, "link_time:", info.LinkTime)
+			pp.Log(ctx, "link_time_exp:", info.LinkTimeExp)
+			pp.Log(ctx, "ShareId:", info.ShareId)
+			pp.Log(ctx, "ShareLink:", info.ShareLink)
+			fileInfos = append(fileInfos, rpc.FileInfo{
+				FileHash:    info.FileHash,
+				FileSize:    info.FileSize,
+				FileName:    info.Name,
+				LinkTime:    info.LinkTime,
 				LinkTimeExp: info.LinkTimeExp,
-				ShareId: info.ShareId,
-				ShareLink: info.ShareLink,
+				ShareId:     info.ShareId,
+				ShareLink:   info.ShareLink,
 			})
 		}
 		rpcResult.Return = rpc.SUCCESS
@@ -101,7 +102,7 @@ func RspShareLink(ctx context.Context, conn core.WriteCloser) {
 		rpcResult.TotalNumber = target.TotalFileNumber
 		rpcResult.PageId = target.PageId
 	} else {
-		utils.ErrorLog("all share failed:", target.Result.Msg)
+		pp.ErrorLog(ctx, "all share failed:", target.Result.Msg)
 		rpcResult.Return = rpc.INTERNAL_COMM_FAILURE
 	}
 	putData(target.ReqId, HTTPShareLink, &target)
@@ -111,7 +112,7 @@ func RspShareLink(ctx context.Context, conn core.WriteCloser) {
 // ReqShareFile
 func ReqShareFile(ctx context.Context, conn core.WriteCloser) {
 	// pp send to SP
-	peers.TransferSendMessageToSPServer(core.MessageFromContext(ctx))
+	peers.TransferSendMessageToSPServer(ctx, core.MessageFromContext(ctx))
 }
 
 // RspShareFile
@@ -128,20 +129,20 @@ func RspShareFile(ctx context.Context, conn core.WriteCloser) {
 	}
 
 	if target.P2PAddress != setting.P2PAddress {
-		peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
+		peers.TransferSendMessageToPPServByP2pAddress(ctx, target.P2PAddress, core.MessageFromContext(ctx))
 		rpcResult.Return = rpc.WRONG_PP_ADDRESS
 		return
 	}
 
 	if target.Result.State == protos.ResultState_RES_SUCCESS {
-		utils.Log("ShareId", target.ShareId)
-		utils.Log("ShareLink", target.ShareLink)
-		utils.Log("SharePassword", target.SharePassword)
+		pp.Log(ctx, "ShareId", target.ShareId)
+		pp.Log(ctx, "ShareLink", target.ShareLink)
+		pp.Log(ctx, "SharePassword", target.SharePassword)
 		rpcResult.Return = rpc.SUCCESS
 		rpcResult.ShareId = target.ShareId
 		rpcResult.ShareLink = target.ShareLink
 	} else {
-		utils.ErrorLog("share file failed:", target.Result.Msg)
+		pp.ErrorLog(ctx, "share file failed:", target.Result.Msg)
 		rpcResult.Return = rpc.INTERNAL_COMM_FAILURE
 	}
 
@@ -152,7 +153,7 @@ func RspShareFile(ctx context.Context, conn core.WriteCloser) {
 // ReqDeleteShare
 func ReqDeleteShare(ctx context.Context, conn core.WriteCloser) {
 	// pp send to SP
-	peers.TransferSendMessageToSPServer(core.MessageFromContext(ctx))
+	peers.TransferSendMessageToSPServer(ctx, core.MessageFromContext(ctx))
 }
 
 // RspDeleteShare
@@ -169,16 +170,16 @@ func RspDeleteShare(ctx context.Context, conn core.WriteCloser) {
 	}
 
 	if target.P2PAddress != setting.P2PAddress {
-		peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
+		peers.TransferSendMessageToPPServByP2pAddress(ctx, target.P2PAddress, core.MessageFromContext(ctx))
 		rpcResult.Return = rpc.WRONG_PP_ADDRESS
 		return
 	}
 
 	if target.Result.State == protos.ResultState_RES_SUCCESS {
-		utils.Log("cancel share success:", target.ShareId)
+		pp.Log(ctx, "cancel share success:", target.ShareId)
 		rpcResult.Return = rpc.SUCCESS
 	} else {
-		utils.ErrorLog("cancel share failed:", target.Result.Msg)
+		pp.ErrorLog(ctx, "cancel share failed:", target.Result.Msg)
 		rpcResult.Return = rpc.GENERIC_ERR
 	}
 	putData(target.ReqId, HTTPDeleteShare, &target)
@@ -186,10 +187,10 @@ func RspDeleteShare(ctx context.Context, conn core.WriteCloser) {
 }
 
 // GetShareFile
-func GetShareFile(keyword, sharePassword, saveAs, reqID, walletAddr string, w http.ResponseWriter) {
-	utils.DebugLog("GetShareFile for file ", keyword)
+func GetShareFile(ctx context.Context, keyword, sharePassword, saveAs, reqID, walletAddr string, w http.ResponseWriter) {
+	pp.DebugLog(ctx, "GetShareFile for file ", keyword)
 	if setting.CheckLogin() {
-		peers.SendMessageDirectToSPOrViaPP(requests.ReqGetShareFileData(keyword, sharePassword, saveAs, reqID, walletAddr), header.ReqGetShareFile)
+		peers.SendMessageDirectToSPOrViaPP(ctx, requests.ReqGetShareFileData(keyword, sharePassword, saveAs, reqID, walletAddr), header.ReqGetShareFile)
 		storeResponseWriter(reqID, w)
 	} else {
 		notLogin(w)
@@ -199,8 +200,8 @@ func GetShareFile(keyword, sharePassword, saveAs, reqID, walletAddr string, w ht
 // ReqGetShareFile
 func ReqGetShareFile(ctx context.Context, conn core.WriteCloser) {
 	// pp send to SP
-	utils.DebugLog("ReqGetShareFile: transferring message to SP server")
-	peers.TransferSendMessageToSPServer(core.MessageFromContext(ctx))
+	pp.DebugLog(ctx, "ReqGetShareFile: transferring message to SP server")
+	peers.TransferSendMessageToSPServer(ctx, core.MessageFromContext(ctx))
 }
 
 // RspGetShareFile
@@ -213,22 +214,22 @@ func RspGetShareFile(ctx context.Context, _ core.WriteCloser) {
 
 	rpcRequested := target.ShareRequest.ReqId != task.LOCAL_REQID
 	if rpcRequested {
-		defer file.SetFileShareResult(target.ShareRequest.WalletAddress + target.ShareRequest.ReqId, rpcResult)
+		defer file.SetFileShareResult(target.ShareRequest.WalletAddress+target.ShareRequest.ReqId, rpcResult)
 	}
 
 	if target.ShareRequest.P2PAddress != setting.P2PAddress {
-		peers.TransferSendMessageToPPServByP2pAddress(target.ShareRequest.P2PAddress, core.MessageFromContext(ctx))
+		peers.TransferSendMessageToPPServByP2pAddress(ctx, target.ShareRequest.P2PAddress, core.MessageFromContext(ctx))
 		rpcResult.Return = rpc.WRONG_PP_ADDRESS
 		return
 	}
 
-	utils.Log("get RspGetShareFile", target.Result.State, target.Result.Msg)
+	pp.Log(ctx, "get RspGetShareFile", target.Result.State, target.Result.Msg)
 	if target.Result.State != protos.ResultState_RES_SUCCESS {
 		rpcResult.Return = rpc.GENERIC_ERR
 		return
 	}
 
-	utils.Log("FileInfo:", target.FileInfo)
+	pp.Log(ctx, "FileInfo:", target.FileInfo)
 	putData(target.ShareRequest.ReqId, HTTPGetShareFile, &target)
 
 	for idx, fileInfo := range target.FileInfo {
@@ -247,14 +248,14 @@ func RspGetShareFile(ctx context.Context, _ core.WriteCloser) {
 			f := rpc.FileInfo{FileHash: fileInfo.FileHash}
 			rpcResult.Return = rpc.SHARED_DL_START
 			rpcResult.FileInfo = append(rpcResult.FileInfo, f)
-			file.SetFileShareResult(target.ShareRequest.WalletAddress + target.ShareRequest.ReqId, rpcResult)
+			file.SetFileShareResult(target.ShareRequest.WalletAddress+target.ShareRequest.ReqId, rpcResult)
 			req, _ = requests.RequestDownloadFile(fileInfo.FileHash, fileInfo.OwnerWalletAddress, target.ShareRequest.ReqId,
 				target.ShareRequest)
 		} else {
 			req = requests.ReqFileStorageInfoData(filePath, "", target.ShareRequest.ReqId, target.ShareRequest.WalletAddress,
 				saveAs, false, target.ShareRequest)
 		}
-		peers.SendMessageDirectToSPOrViaPP(req, header.ReqFileStorageInfo)
+		peers.SendMessageDirectToSPOrViaPP(ctx, req, header.ReqFileStorageInfo)
 	}
 	return
 }

--- a/pp/event/sys_info.go
+++ b/pp/event/sys_info.go
@@ -24,9 +24,9 @@ func ReqGetHDInfo(ctx context.Context, conn core.WriteCloser) {
 	if requests.UnmarshalData(ctx, &target) {
 
 		if setting.P2PAddress == target.P2PAddress {
-			peers.SendMessageToSPServer(requests.RspGetHDInfoData(), header.RspGetHDInfo)
+			peers.SendMessageToSPServer(ctx, requests.RspGetHDInfoData(), header.RspGetHDInfo)
 		} else {
-			peers.TransferSendMessageToPPServByP2pAddress(target.P2PAddress, core.MessageFromContext(ctx))
+			peers.TransferSendMessageToPPServByP2pAddress(ctx, target.P2PAddress, core.MessageFromContext(ctx))
 		}
 	}
 }
@@ -34,23 +34,25 @@ func ReqGetHDInfo(ctx context.Context, conn core.WriteCloser) {
 // RspGetHDInfo
 func RspGetHDInfo(ctx context.Context, conn core.WriteCloser) {
 
-	peers.TransferSendMessageToSPServer(core.MessageFromContext(ctx))
+	peers.TransferSendMessageToSPServer(ctx, core.MessageFromContext(ctx))
 }
 
-func reportDHInfo() {
-	peers.SendMessageToSPServer(requests.RspGetHDInfoData(), header.RspGetHDInfo)
+func reportDHInfo(ctx context.Context) func() {
+	return func() {
+		peers.SendMessageToSPServer(ctx, requests.RspGetHDInfoData(), header.RspGetHDInfo)
+	}
 }
 
-func reportDHInfoToPP() {
-	peers.SendMessage(client.PPConn, requests.RspGetHDInfoData(), header.RspGetHDInfo)
+func reportDHInfoToPP(ctx context.Context) {
+	peers.SendMessage(ctx, client.PPConn, requests.RspGetHDInfoData(), header.RspGetHDInfo)
 }
 
-func startReportDHInfo() {
+func startReportDHInfo(ctx context.Context) {
 	if job != nil {
 		job.Cancel()
 	}
-	peers.SendMessageToSPServer(requests.RspGetHDInfoData(), header.RspGetHDInfo)
-	job, _ = myClock.AddJobRepeat(time.Second*setting.REPORTDHTIME, 0, reportDHInfo)
+	peers.SendMessageToSPServer(ctx, requests.RspGetHDInfoData(), header.RspGetHDInfo)
+	job, _ = myClock.AddJobRepeat(time.Second*setting.REPORTDHTIME, 0, reportDHInfo(ctx))
 }
 
 // GetCapacity GetCapacity

--- a/pp/event/timeout_handler.go
+++ b/pp/event/timeout_handler.go
@@ -1,9 +1,11 @@
 package event
 
 import (
+	"context"
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg"
 	"github.com/stratosnet/sds/msg/protos"
 	"github.com/stratosnet/sds/pp/requests"
@@ -28,7 +30,8 @@ func (handler *DownloadTimeoutHandler) Handle(message *msg.RelayMsgBuf) {
 		return
 	}
 
-	setDownloadSliceFail(target.SliceInfo.SliceHash, target.TaskId, target.IsVideoCaching, dTask)
+	ctx := core.CreateContextWithParentReqId(context.Background(), message.MSGHead.ReqId)
+	setDownloadSliceFail(ctx, target.SliceInfo.SliceHash, target.TaskId, target.IsVideoCaching, dTask)
 }
 
 func (handler *DownloadTimeoutHandler) GetDuration() time.Duration {

--- a/pp/event/upload_file.go
+++ b/pp/event/upload_file.go
@@ -309,8 +309,8 @@ func sendUploadFileSlice(ctx context.Context, target *protos.RspUploadFile) {
 		}
 
 	} else {
-		for _, pp := range ING.Slices {
-			uploadTask := task.GetUploadSliceTask(ctx, pp, target.FileHash, target.TaskId, target.SpP2PAddress,
+		for _, ppNode := range ING.Slices {
+			uploadTask := task.GetUploadSliceTask(ctx, ppNode, target.FileHash, target.TaskId, target.SpP2PAddress,
 				target.IsVideoStream, target.IsEncrypted, ING.FileCRC)
 			if uploadTask != nil {
 				UploadFileSlice(ctx, uploadTask, target.Sign)

--- a/pp/event/upload_file.go
+++ b/pp/event/upload_file.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
+	"github.com/stratosnet/sds/pp/api/rpc"
 	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/peers"
@@ -20,7 +22,6 @@ import (
 	"github.com/stratosnet/sds/pp/task"
 	"github.com/stratosnet/sds/utils"
 	"github.com/stratosnet/sds/utils/httpserv"
-	"github.com/stratosnet/sds/pp/api/rpc"
 )
 
 //var m *sync.WaitGroup
@@ -28,6 +29,7 @@ var isCover bool
 
 // RequestUploadCoverImage RequestUploadCoverImage
 func RequestUploadCoverImage(pathStr, reqID string, w http.ResponseWriter) {
+	ctx := context.Background()
 	isCover = true
 	tmpString, err := utils.ImageCommpress(pathStr)
 	utils.DebugLog("reqID", reqID)
@@ -38,14 +40,14 @@ func RequestUploadCoverImage(pathStr, reqID string, w http.ResponseWriter) {
 		}
 		return
 	}
-	p := requests.RequestUploadFileData(tmpString, "", reqID, setting.WalletAddress, true, false, false)
-	peers.SendMessageToSPServer(p, header.ReqUploadFile)
+	p := requests.RequestUploadFileData(ctx, tmpString, "", reqID, setting.WalletAddress, true, false, false)
+	peers.SendMessageToSPServer(ctx, p, header.ReqUploadFile)
 	storeResponseWriter(reqID, w)
 }
 
 // RequestUploadFile request to SP for upload file
-func RequestUploadFile(path, reqID string, isEncrypted bool, _ http.ResponseWriter) {
-	utils.DebugLog("______________path", path)
+func RequestUploadFile(ctx context.Context, path, reqID string, isEncrypted bool, _ http.ResponseWriter) {
+	pp.DebugLog(ctx, "______________path", path)
 	if !setting.CheckLogin() {
 		return
 	}
@@ -56,134 +58,134 @@ func RequestUploadFile(path, reqID string, isEncrypted bool, _ http.ResponseWrit
 		return
 	}
 	if isFile {
-		p := requests.RequestUploadFileData(path, "", reqID, setting.WalletAddress, false, false, isEncrypted)
-		peers.SendMessageToSPServer(p, header.ReqUploadFile)
+		p := requests.RequestUploadFileData(ctx, path, "", reqID, setting.WalletAddress, false, false, isEncrypted)
+		peers.SendMessageToSPServer(ctx, p, header.ReqUploadFile)
 		return
 	}
 
 	// is directory
-	utils.DebugLog("this is a directory, not file")
+	pp.DebugLog(ctx, "this is a directory, not file")
 	file.GetAllFiles(path)
 	for {
 		select {
 		case pathString := <-setting.UpChan:
-			utils.DebugLog("path string == ", pathString)
-			p := requests.RequestUploadFileData(pathString, "", reqID, setting.WalletAddress, false, false, isEncrypted)
-			peers.SendMessageToSPServer(p, header.ReqUploadFile)
+			pp.DebugLog(ctx, "path string == ", pathString)
+			p := requests.RequestUploadFileData(ctx, pathString, "", reqID, setting.WalletAddress, false, false, isEncrypted)
+			peers.SendMessageToSPServer(ctx, p, header.ReqUploadFile)
 		default:
 			return
 		}
 	}
 }
 
-func RequestUploadStream(path, reqID string, _ http.ResponseWriter) {
-	utils.DebugLog("______________path", path)
+func RequestUploadStream(ctx context.Context, path, reqID string, _ http.ResponseWriter) {
+	pp.DebugLog(ctx, "______________path", path)
 	if !setting.CheckLogin() {
 		return
 	}
 	isFile, err := file.IsFile(path)
 	if err != nil {
-		utils.ErrorLog(err)
+		pp.ErrorLog(ctx, err)
 		return
 	}
 	if isFile {
-		p := requests.RequestUploadFileData(path, "", reqID, setting.WalletAddress, false, true, false)
+		p := requests.RequestUploadFileData(ctx, path, "", reqID, setting.WalletAddress, false, true, false)
 		if p != nil {
-			peers.SendMessageToSPServer(p, header.ReqUploadFile)
+			peers.SendMessageToSPServer(ctx, p, header.ReqUploadFile)
 		}
 		return
 	} else {
-		utils.ErrorLog("the provided path indicates a directory, not a file")
+		pp.ErrorLog(ctx, "the provided path indicates a directory, not a file")
 		return
 	}
 }
 
-func ScheduleReqBackupStatus(fileHash string) {
+func ScheduleReqBackupStatus(ctx context.Context, fileHash string) {
 	time.AfterFunc(5*time.Minute, func() {
-		ReqBackupStatus(fileHash)
+		ReqBackupStatus(ctx, fileHash)
 	})
 }
 
-func ReqBackupStatus(fileHash string) {
+func ReqBackupStatus(ctx context.Context, fileHash string) {
 	p := &protos.ReqBackupStatus{
 		FileHash:      fileHash,
 		P2PAddress:    setting.P2PAddress,
 		WalletAddress: setting.WalletAddress,
 	}
-	peers.SendMessageToSPServer(p, header.ReqFileBackupStatus)
+	peers.SendMessageToSPServer(ctx, p, header.ReqFileBackupStatus)
 }
 
 // RspUploadFile response of upload file event
 func RspUploadFile(ctx context.Context, _ core.WriteCloser) {
-	utils.DebugLog("get RspUploadFile")
+	pp.DebugLog(ctx, "get RspUploadFile")
 	target := &protos.RspUploadFile{}
 	if !requests.UnmarshalData(ctx, target) {
-		utils.ErrorLog("unmarshal error")
+		pp.ErrorLog(ctx, "unmarshal error")
 		return
 	}
 	// upload file to PP based on the PP info provided by SP
 	if target.Result == nil {
-		utils.ErrorLog("target.Result is nil")
+		pp.ErrorLog(ctx, "target.Result is nil")
 
 	} else if target.Result.State != protos.ResultState_RES_SUCCESS {
 		if strings.Contains(target.Result.Msg, "Same file with the name") {
-			utils.Log(target.Result.Msg)
+			pp.Log(ctx, target.Result.Msg)
 		} else {
-			utils.Log("upload failed: ", target.Result.Msg)
+			pp.Log(ctx, "upload failed: ", target.Result.Msg)
 		}
 
 		if file.IsFileRpcRemote(target.FileHash) {
 			file.SetRemoteFileResult(target.FileHash, rpc.Result{Return: target.Result.Msg})
-		}else {
+		} else {
 			file.ClearFileMap(target.FileHash)
 		}
 
 	} else if len(target.PpList) != 0 {
-		go startUploadTask(target)
+		go startUploadTask(ctx, target)
 
 	} else {
-		utils.Log("file upload successful！  fileHash", target.FileHash)
+		pp.Log(ctx, "file upload successful！  fileHash", target.FileHash)
 		var p float32 = 100
 		ProgressMap.Store(target.FileHash, p)
 		task.UploadProgressMap.Delete(target.FileHash)
 
 		if file.IsFileRpcRemote(target.FileHash) {
-			file.SetRemoteFileResult(target.FileHash, rpc.Result{Return:rpc.SUCCESS})
+			file.SetRemoteFileResult(target.FileHash, rpc.Result{Return: rpc.SUCCESS})
 		}
 	}
 	if isCover {
-		utils.DebugLog("is_cover", target.ReqId)
+		pp.DebugLog(ctx, "is_cover", target.ReqId)
 		putData(target.ReqId, HTTPUploadFile, target)
 	}
 
 }
 
 func RspBackupStatus(ctx context.Context, _ core.WriteCloser) {
-	utils.DebugLog("get RspBackupStatus")
+	pp.DebugLog(ctx, "get RspBackupStatus")
 	target := &protos.RspBackupStatus{}
 	if !requests.UnmarshalData(ctx, target) {
-		utils.ErrorLog("unmarshal error")
+		pp.ErrorLog(ctx, "unmarshal error")
 		return
 	}
 
 	if target.Result.State == protos.ResultState_RES_FAIL {
-		utils.Log("Backup status check failed", target.Result.Msg)
+		pp.Log(ctx, "Backup status check failed", target.Result.Msg)
 		return
 	}
 
-	utils.Logf("Backup status for file %s: the number of replica is %d", target.FileHash, target.Replicas)
+	pp.Logf(ctx, "Backup status for file %s: the number of replica is %d", target.FileHash, target.Replicas)
 	if target.DeleteOriginTmp {
-		utils.Logf("Backup is finished for file %s, delete all the temporary slices", target.FileHash)
-		file.DeleteTmpFileSlices(target.FileHash)
+		pp.Logf(ctx, "Backup is finished for file %s, delete all the temporary slices", target.FileHash)
+		file.DeleteTmpFileSlices(ctx, target.FileHash)
 		return
 	}
 
 	if len(target.PpList) == 0 {
-		ScheduleReqBackupStatus(target.FileHash)
+		ScheduleReqBackupStatus(ctx, target.FileHash)
 		return
 	}
 
-	utils.Logf("Start re-uploading slices for the file  %s", target.FileHash)
+	pp.Logf(ctx, "Start re-uploading slices for the file  %s", target.FileHash)
 	totalSize := int64(0)
 	var sliceAddrList []*protos.SliceNumAddr
 	for _, sliceHashAddr := range target.PpList {
@@ -213,16 +215,16 @@ func RspBackupStatus(ctx context.Context, _ core.WriteCloser) {
 	for _, pp := range target.PpList {
 		uploadTask := task.GetReuploadSliceTask(pp, target.FileHash, target.TaskId, target.SpP2PAddress)
 		if uploadTask != nil {
-			UploadFileSlice(uploadTask, target.Sign)
+			UploadFileSlice(ctx, uploadTask, target.Sign)
 		}
 	}
-	utils.DebugLog("all slices of the task have begun uploading")
+	pp.DebugLog(ctx, "all slices of the task have begun uploading")
 	close(taskING.UpChan)
 	task.UpIngMap.Delete(target.FileHash)
 }
 
 // startUploadTask
-func startUploadTask(target *protos.RspUploadFile) {
+func startUploadTask(ctx context.Context, target *protos.RspUploadFile) {
 	// // create upload task
 	slices := target.PpList
 	taskING := &task.UpFileIng{
@@ -238,9 +240,9 @@ func startUploadTask(target *protos.RspUploadFile) {
 	var streamTotalSize int64
 	var hlsInfo file.HlsInfo
 	if target.IsVideoStream {
-		file.VideoToHls(target.FileHash)
+		file.VideoToHls(ctx, target.FileHash)
 		if hlsInfo, err := file.GetHlsInfo(target.FileHash, uint64(len(target.PpList))); err != nil {
-			utils.ErrorLog("Hls transformation failed: ", err)
+			pp.ErrorLog(ctx, "Hls transformation failed: ", err)
 			return
 		} else {
 			streamTotalSize = hlsInfo.TotalSize
@@ -255,10 +257,10 @@ func startUploadTask(target *protos.RspUploadFile) {
 		}
 		progress.HasUpload = (target.TotalSlice - int64(len(target.PpList))) * 32 * 1024 * 1024
 	}
-	go sendUploadFileSlice(target)
+	go sendUploadFileSlice(ctx, target)
 }
 
-func up(ING *task.UpFileIng, target *protos.RspUploadFile) {
+func up(ctx context.Context, ING *task.UpFileIng, target *protos.RspUploadFile) {
 	for {
 		select {
 		case goon := <-ING.UpChan:
@@ -267,54 +269,54 @@ func up(ING *task.UpFileIng, target *protos.RspUploadFile) {
 			}
 
 			if len(ING.Slices) == 0 {
-				utils.DebugLog("all slices of the task have begun uploading")
+				pp.DebugLog(ctx, "all slices of the task have begun uploading")
 				if _, ok := <-ING.UpChan; ok {
 					close(ING.UpChan)
 				}
 				task.UpIngMap.Delete(target.FileHash)
 
 				if target.IsVideoStream {
-					file.DeleteTmpHlsFolder(target.FileHash)
+					file.DeleteTmpHlsFolder(ctx, target.FileHash)
 				}
 
 				return
 			}
-			pp := ING.Slices[0]
-			utils.DebugLog("start upload!!!!!", pp.SliceNumber)
-			uploadTask := task.GetUploadSliceTask(pp, ING.FileHash, ING.TaskID, target.SpP2PAddress,
+			ppNode := ING.Slices[0]
+			pp.DebugLog(ctx, "start upload!!!!!", ppNode.SliceNumber)
+			uploadTask := task.GetUploadSliceTask(ctx, ppNode, ING.FileHash, ING.TaskID, target.SpP2PAddress,
 				target.IsVideoStream, target.IsEncrypted, ING.FileCRC)
 			if uploadTask == nil {
 				continue
 			}
 
-			UploadFileSlice(uploadTask, target.Sign)
+			UploadFileSlice(ctx, uploadTask, target.Sign)
 			ING.Slices = append(ING.Slices[:0], ING.Slices[0+1:]...)
 		}
 	}
 }
 
-func sendUploadFileSlice(target *protos.RspUploadFile) {
+func sendUploadFileSlice(ctx context.Context, target *protos.RspUploadFile) {
 	ing, ok := task.UpIngMap.Load(target.FileHash)
 	if !ok {
-		utils.DebugLog("all slices of the task have begun uploading")
+		pp.DebugLog(ctx, "all slices of the task have begun uploading")
 		return
 	}
 	ING := ing.(*task.UpFileIng)
 	if len(ING.Slices) > task.MAXSLICE {
-		go up(ING, target)
+		go up(ctx, ING, target)
 		for i := 0; i < task.MAXSLICE; i++ {
 			ING.UpChan <- true
 		}
 
 	} else {
 		for _, pp := range ING.Slices {
-			uploadTask := task.GetUploadSliceTask(pp, target.FileHash, target.TaskId, target.SpP2PAddress,
+			uploadTask := task.GetUploadSliceTask(ctx, pp, target.FileHash, target.TaskId, target.SpP2PAddress,
 				target.IsVideoStream, target.IsEncrypted, ING.FileCRC)
 			if uploadTask != nil {
-				UploadFileSlice(uploadTask, target.Sign)
+				UploadFileSlice(ctx, uploadTask, target.Sign)
 			}
 		}
-		utils.DebugLog("all slices of the task have begun uploading")
+		pp.DebugLog(ctx, "all slices of the task have begun uploading")
 		_, ok := <-ING.UpChan
 		if ok {
 			close(ING.UpChan)
@@ -322,13 +324,13 @@ func sendUploadFileSlice(target *protos.RspUploadFile) {
 		task.UpIngMap.Delete(target.FileHash)
 
 		if target.IsVideoStream {
-			file.DeleteTmpHlsFolder(target.FileHash)
+			file.DeleteTmpHlsFolder(ctx, target.FileHash)
 		}
 	}
 }
 
-func uploadKeep(fileHash, taskID string) {
-	utils.DebugLogf("uploadKeep  fileHash = %v  taskID = %v", fileHash, taskID)
+func uploadKeep(ctx context.Context, fileHash, taskID string) {
+	pp.DebugLogf(ctx, "uploadKeep  fileHash = %v  taskID = %v", fileHash, taskID)
 	if ing, ok := task.UpIngMap.Load(fileHash); ok {
 		ING := ing.(*task.UpFileIng)
 		ING.UpChan <- true
@@ -336,12 +338,12 @@ func uploadKeep(fileHash, taskID string) {
 }
 
 // UploadPause
-func UploadPause(fileHash, reqID string, w http.ResponseWriter) {
+func UploadPause(ctx context.Context, fileHash, reqID string, w http.ResponseWriter) {
 	client.UpConnMap.Range(func(k, v interface{}) bool {
 		if strings.HasPrefix(k.(string), fileHash) {
 			conn := v.(*cf.ClientConn)
 			conn.ClientClose()
-			utils.DebugLog("UploadPause", conn)
+			pp.DebugLog(ctx, "UploadPause", conn)
 		}
 		return true
 	})

--- a/pp/file/file.go
+++ b/pp/file/file.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	"encoding/csv"
 	"io/ioutil"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/utils"
 )
@@ -108,31 +110,31 @@ func GetSliceSize(sliceHash string) int64 {
 
 }
 
-func SaveTmpSliceData(fileHash, sliceHash string, data []byte) bool {
+func SaveTmpSliceData(ctx context.Context, fileHash, sliceHash string, data []byte) bool {
 	wmutex.Lock()
 	defer wmutex.Unlock()
 	tmpFileFolderPath := getTmpFileFolderPath(fileHash)
 	folderPath := filepath.Join(tmpFileFolderPath)
 	exist, err := PathExists(folderPath)
 	if err != nil {
-		utils.ErrorLog(err)
+		pp.ErrorLog(ctx, err)
 		return false
 	}
 	if !exist {
 		if err = os.MkdirAll(folderPath, os.ModePerm); err != nil {
-			utils.ErrorLog(err)
+			pp.ErrorLog(ctx, err)
 			return false
 		}
 	}
 	fileMg, err := os.OpenFile(getTmpSlicePath(fileHash, sliceHash), os.O_CREATE|os.O_RDWR, 0777)
 	defer fileMg.Close()
 	if err != nil {
-		utils.ErrorLog("error initialize file")
+		pp.ErrorLog(ctx, "error initialize file")
 		return false
 	}
 	_, err = fileMg.Write(data)
 	if err != nil {
-		utils.ErrorLog("error save file")
+		pp.ErrorLog(ctx, "error save file")
 		return false
 	}
 	return true
@@ -157,13 +159,13 @@ func SaveSliceData(data []byte, sliceHash string, offset uint64) bool {
 }
 
 // SaveFileData
-func SaveFileData(data []byte, offset int64, sliceHash, fileName, fileHash, savePath, fileReqId string) bool {
+func SaveFileData(ctx context.Context, data []byte, offset int64, sliceHash, fileName, fileHash, savePath, fileReqId string) bool {
 
 	utils.DebugLog("sliceHash", sliceHash)
 
 	if IsFileRpcRemote(fileHash + fileReqId) {
 		// write to rpc
-		return SaveRemoteFileData(fileHash + fileReqId, data, uint64(offset))
+		return SaveRemoteFileData(fileHash+fileReqId, data, uint64(offset))
 	}
 	wmutex.Lock()
 	if fileName == "" {
@@ -172,17 +174,17 @@ func SaveFileData(data []byte, offset int64, sliceHash, fileName, fileHash, save
 	fileMg, err := os.OpenFile(GetDownloadTmpPath(fileHash, fileName, savePath), os.O_CREATE|os.O_RDWR, 0777)
 	defer fileMg.Close()
 	if err != nil {
-		utils.Log("SaveFileData err", err)
+		pp.Log(ctx, "SaveFileData err", err)
 	}
 	if err != nil {
-		utils.ErrorLog("error initialize file")
+		pp.ErrorLog(ctx, "error initialize file")
 		wmutex.Unlock()
 		return false
 	}
 	// _, err = fileMg.WriteAt(data, offset)
 	_, err = fileMg.Seek(offset, 0)
 	if err != nil {
-		utils.ErrorLog("error save file")
+		pp.ErrorLog(ctx, "error save file")
 		wmutex.Unlock()
 		return false
 	}
@@ -192,23 +194,22 @@ func SaveFileData(data []byte, offset int64, sliceHash, fileName, fileHash, save
 }
 
 // SaveDownloadProgress
-func SaveDownloadProgress(sliceHash, fileName, fileHash, savePath, fileReqId string) {
+func SaveDownloadProgress(ctx context.Context, sliceHash, fileName, fileHash, savePath, fileReqId string) {
 	if IsFileRpcRemote(fileHash + fileReqId) {
 		return
 	}
-
 	wmutex.Lock()
 	csvFile, err := os.OpenFile(GetDownloadCsvPath(fileHash, fileName, savePath), os.O_CREATE|os.O_RDWR|os.O_APPEND, 0777)
 	defer csvFile.Close()
 	defer wmutex.Unlock()
 	if err != nil {
-		utils.ErrorLog("error open downloaded file records")
+		pp.ErrorLog(ctx, "error open downloaded file records")
 	}
 	writer := csv.NewWriter(csvFile)
 	line := []string{sliceHash}
 	err = writer.Write(line)
 	if err != nil {
-		utils.ErrorLog("download csv line ", err)
+		pp.ErrorLog(ctx, "download csv line ", err)
 	}
 	writer.Flush()
 }
@@ -250,14 +251,13 @@ func RecordDownloadCSV(target *protos.RspFileStorageInfo) {
 }
 
 // CheckFileExisting
-func CheckFileExisting(fileHash, fileName, savePath, encryptionTag, fileReqId string) bool {
-	utils.DebugLog("CheckFileExisting: file Hash", fileHash)
+func CheckFileExisting(ctx context.Context, fileHash, fileName, savePath, encryptionTag, fileReqId string) bool {
+	pp.DebugLog(ctx, "CheckFileExisting: file Hash", fileHash)
 
 	// check if the target path is remote, return false for "not match"
 	if IsFileRpcRemote(fileHash + fileReqId) {
 		return false
 	}
-
 	filePath := ""
 	if savePath == "" {
 		filePath = filepath.Join(setting.Config.DownloadPath, fileName)
@@ -267,21 +267,21 @@ func CheckFileExisting(fileHash, fileName, savePath, encryptionTag, fileReqId st
 	// if setting.IsWindows {
 	//	filePath = filepath.FromSlash(filePath)
 	// }
-	utils.DebugLog("filePath", filePath)
+	pp.DebugLog(ctx, "filePath", filePath)
 	file, err := os.OpenFile(filePath, os.O_RDONLY, 0777)
 	defer file.Close()
 	if err != nil {
-		utils.DebugLog("no directory specified, thus no file slices")
+		pp.DebugLog(ctx, "no directory specified, thus no file slices")
 		return false
 	}
 
 	hash := utils.CalcFileHash(filePath, encryptionTag)
-	utils.DebugLog("hash", hash)
+	pp.DebugLog(ctx, "hash", hash)
 	if hash == fileHash {
-		utils.DebugLog("file hash matched")
+		pp.DebugLog(ctx, "file hash matched")
 		return true
 	}
-	utils.DebugLog("file hash not match")
+	pp.DebugLog(ctx, "file hash not match")
 	return false
 }
 
@@ -333,10 +333,10 @@ func DeleteDirectory(fileHash string) {
 
 }
 
-func DeleteTmpFileSlices(fileHash string) {
+func DeleteTmpFileSlices(ctx context.Context, fileHash string) {
 	err := os.RemoveAll(filepath.Join(setting.GetRootPath(), TEMP_FOLDER, fileHash))
 	if err != nil {
-		utils.DebugLog("Delete tmp folder err", err)
+		pp.DebugLog(ctx, "Delete tmp folder err", err)
 	}
 }
 

--- a/pp/log.go
+++ b/pp/log.go
@@ -9,7 +9,7 @@ import (
 )
 
 func logDepthWithContext(context context.Context, level utils.LogLevel, calldepth int, v ...interface{}) {
-	utils.MyLogger.LogDepth(level, 3, v...)
+	utils.MyLogger.LogDepth(level, calldepth+1, v...)
 
 	if context == nil {
 		return
@@ -50,25 +50,25 @@ func CreateReqIdAndRegisterRpcLogger(ctx context.Context) context.Context {
 }
 
 func Log(ctx context.Context, v ...interface{}) {
-	logDepthWithContext(ctx, utils.Info, 3, v...)
+	logDepthWithContext(ctx, utils.Info, 4, v...)
 }
 
 func Logf(ctx context.Context, template string, v ...interface{}) {
-	logDepthWithContext(ctx, utils.Info, 3, fmt.Sprintf(template, v...))
+	logDepthWithContext(ctx, utils.Info, 4, fmt.Sprintf(template, v...))
 }
 
 func ErrorLog(ctx context.Context, v ...interface{}) {
-	logDepthWithContext(ctx, utils.Error, 3, v...)
+	logDepthWithContext(ctx, utils.Error, 4, v...)
 }
 
 func ErrorLogf(ctx context.Context, template string, v ...interface{}) {
-	logDepthWithContext(ctx, utils.Error, 3, fmt.Errorf(template, v...))
+	logDepthWithContext(ctx, utils.Error, 4, fmt.Errorf(template, v...))
 }
 
 func DebugLog(ctx context.Context, v ...interface{}) {
-	logDepthWithContext(ctx, utils.Debug, 3, v...)
+	logDepthWithContext(ctx, utils.Debug, 4, v...)
 }
 
 func DebugLogf(ctx context.Context, template string, v ...interface{}) {
-	logDepthWithContext(ctx, utils.Debug, 3, fmt.Sprintf(template, v...))
+	logDepthWithContext(ctx, utils.Debug, 4, fmt.Sprintf(template, v...))
 }

--- a/pp/log.go
+++ b/pp/log.go
@@ -1,0 +1,74 @@
+package pp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stratosnet/sds/framework/core"
+	"github.com/stratosnet/sds/utils"
+)
+
+func logDepthWithContext(context context.Context, level utils.LogLevel, calldepth int, v ...interface{}) {
+	utils.MyLogger.LogDepth(level, 3, v...)
+
+	if context == nil {
+		return
+	}
+
+	loggerKey := getLoggerMapKeyFromContext(context)
+
+	if loggerKey == 0 {
+		return
+	}
+
+	if value, ok := utils.RpcLoggerMap.Load(loggerKey); ok {
+		rpcLogger := value.(*utils.Logger)
+		rpcLogger.LogDepth(level, calldepth, v...)
+	}
+}
+
+func getLoggerMapKeyFromContext(ctx context.Context) int64 {
+	if ctx == nil {
+		return 0
+	}
+
+	if parentReqId := core.GetParentReqIdFromContext(ctx); parentReqId > 0 {
+		return parentReqId
+	}
+
+	if reqId := core.GetReqIdFromContext(ctx); reqId > 0 {
+		return reqId
+	}
+
+	return 0
+}
+
+func CreateReqIdAndRegisterRpcLogger(ctx context.Context) context.Context {
+	reqId, _ := utils.NextSnowFakeId()
+	utils.RpcLoggerMap.Store(reqId, utils.RpcLogger)
+	return core.CreateContextWithReqId(ctx, reqId)
+}
+
+func Log(ctx context.Context, v ...interface{}) {
+	logDepthWithContext(ctx, utils.Info, 3, v...)
+}
+
+func Logf(ctx context.Context, template string, v ...interface{}) {
+	logDepthWithContext(ctx, utils.Info, 3, fmt.Sprintf(template, v...))
+}
+
+func ErrorLog(ctx context.Context, v ...interface{}) {
+	logDepthWithContext(ctx, utils.Error, 3, v...)
+}
+
+func ErrorLogf(ctx context.Context, template string, v ...interface{}) {
+	logDepthWithContext(ctx, utils.Error, 3, fmt.Errorf(template, v...))
+}
+
+func DebugLog(ctx context.Context, v ...interface{}) {
+	logDepthWithContext(ctx, utils.Debug, 3, v...)
+}
+
+func DebugLogf(ctx context.Context, template string, v ...interface{}) {
+	logDepthWithContext(ctx, utils.Debug, 3, fmt.Sprintf(template, v...))
+}

--- a/pp/peers/node_status.go
+++ b/pp/peers/node_status.go
@@ -1,28 +1,32 @@
 package peers
 
 import (
+	"context"
+
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/requests"
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/pp/types"
-	"github.com/stratosnet/sds/utils"
 )
 
 // ReportNodeStatus
-func ReportNodeStatus() {
-	if setting.IsStartMining && setting.State == types.PP_ACTIVE {
-		status := requests.ReqNodeStatusData()
-		go doReportNodeStatus(status)
+func ReportNodeStatus(ctx context.Context) func() {
+	return func() {
+		if setting.IsStartMining && setting.State == types.PP_ACTIVE {
+			status := requests.ReqNodeStatusData()
+			go doReportNodeStatus(ctx, status)
+		}
 	}
 }
 
-func doReportNodeStatus(status *protos.ReqReportNodeStatus) {
-	utils.DebugLog("Sending RNS message to SP! " + status.String())
-	SendMessageToSPServer(status, header.ReqReportNodeStatus)
+func doReportNodeStatus(ctx context.Context, status *protos.ReqReportNodeStatus) {
+	pp.DebugLog(ctx, "Sending RNS message to SP! "+status.String())
+	SendMessageToSPServer(ctx, status, header.ReqReportNodeStatus)
 	// if current reachable is too less, try refresh the list
-	_, total, _ := peerList.GetPPList()
+	_, total, _ := peerList.GetPPList(ctx)
 	if total > 0 && total <= 2 {
-		GetPPListFromSP()
+		GetPPListFromSP(ctx)
 	}
 }

--- a/pp/peers/pp.go
+++ b/pp/peers/pp.go
@@ -1,12 +1,13 @@
 package peers
 
 import (
+	"context"
 	"net"
 
 	"github.com/alex023/clock"
 	"github.com/stratosnet/sds/framework/core"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/setting"
-	"github.com/stratosnet/sds/utils"
 )
 
 //todo: pp server should be move out of peers package
@@ -36,32 +37,32 @@ func SetPPServer(pp *PPServer) {
 }
 
 // StartListenServer
-func StartListenServer(port string) {
+func StartListenServer(ctx context.Context, port string) {
 	netListen, err := net.Listen(setting.PP_SERVER_TYPE, ":"+port)
 	if err != nil {
-		utils.ErrorLog("StartListenServer", err)
+		pp.ErrorLog(ctx, "StartListenServer", err)
 	}
-	spbServer := NewServer()
+	spbServer := NewServer(ctx)
 	ppServ = spbServer
-	utils.Log("StartListenServer!!! ", port)
+	pp.Log(ctx, "StartListenServer!!! ", port)
 	err = spbServer.Start(netListen)
 	if err != nil {
-		utils.ErrorLog("StartListenServer Error", err)
+		pp.ErrorLog(ctx, "StartListenServer Error", err)
 	}
 }
 
 // NewServer returns a server.
-func NewServer() *PPServer {
+func NewServer(ctx context.Context) *PPServer {
 	onConnectOption := core.OnConnectOption(func(conn core.WriteCloser) bool {
-		utils.Log("on connect")
+		pp.Log(ctx, "on connect")
 		return true
 	})
 	onErrorOption := core.OnErrorOption(func(conn core.WriteCloser) {
-		utils.Log("on error")
+		pp.Log(ctx, "on error")
 	})
 	onCloseOption := core.OnCloseOption(func(conn core.WriteCloser) {
 		netID := conn.(*core.ServerConn).GetNetID()
-		peerList.PPDisconnectedNetId(netID)
+		peerList.PPDisconnectedNetId(ctx, netID)
 	})
 
 	maxConnection := setting.DEFAULT_MAX_CONNECTION
@@ -86,7 +87,7 @@ func NewServer() *PPServer {
 		core.LogInboundOption(PP_LOG_INBOUND),
 		core.LogOutboundOption(PP_LOG_OUTBOUND),
 		core.OnStartLogOption(func(s *core.Server) {
-			utils.Log("on start volume log")
+			pp.Log(ctx, "on start volume log")
 			s.AddVolumeLogJob(PP_LOG_ALL, PP_LOG_READ, PP_LOG_WRITE, PP_LOG_INBOUND, PP_LOG_OUTBOUND)
 		}),
 	)

--- a/pp/peers/pp_list.go
+++ b/pp/peers/pp_list.go
@@ -1,13 +1,15 @@
 package peers
 
 import (
-	"time"
+	"context"
 	"strconv"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stratosnet/sds/msg"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/requests"
 	"github.com/stratosnet/sds/pp/setting"
@@ -25,51 +27,51 @@ const (
 )
 
 // InitPPList
-func InitPPList() {
-	pplist, _, _ := peerList.GetPPList()
+func InitPPList(ctx context.Context) {
+	pplist, _, _ := peerList.GetPPList(ctx)
 	if len(pplist) == 0 {
-		GetPPListFromSP()
+		GetPPListFromSP(ctx)
 	} else {
-		if success := ConnectToGatewayPP(pplist); !success {
-			GetPPListFromSP()
+		if success := ConnectToGatewayPP(ctx, pplist); !success {
+			GetPPListFromSP(ctx)
 			return
 		}
 		if setting.IsAuto && setting.State == types.PP_ACTIVE && !setting.IsLoginToSP {
-			RegisterToSP(true)
+			RegisterToSP(ctx, true)
 		}
 	}
 }
 
-func StartPpLatencyCheck() {
-	ppPeerClock.AddJobRepeat(time.Second*setting.PpLatencyCheckInterval, 0, LatencyOfNextPp)
+func StartPpLatencyCheck(ctx context.Context) {
+	ppPeerClock.AddJobRepeat(time.Second*setting.PpLatencyCheckInterval, 0, LatencyOfNextPp(ctx))
 }
 
-func StartStatusReportToSP() {
+func StartStatusReportToSP(ctx context.Context) {
 	utils.DebugLog("Status will be reported to SP while mining")
 	// trigger first report at time-0 immediately
-	ReportNodeStatus()
+	ReportNodeStatus(ctx)()
 	// trigger consecutive reports with interval
-	ppPeerClock.AddJobRepeat(time.Second*setting.NodeReportIntervalSec, 0, ReportNodeStatus)
+	ppPeerClock.AddJobRepeat(time.Second*setting.NodeReportIntervalSec, 0, ReportNodeStatus(ctx))
 }
 
 // GetPPListFromSP node get ppList from sp
-func GetPPListFromSP() {
-	utils.DebugLog("SendMessage(client.SPConn, req, header.ReqGetPPList)")
-	SendMessageToSPServer(requests.ReqGetPPlistData(), header.ReqGetPPList)
+func GetPPListFromSP(ctx context.Context) {
+	pp.DebugLog(ctx, "SendMessage(client.SPConn, req, header.ReqGetPPList)")
+	SendMessageToSPServer(ctx, requests.ReqGetPPlistData(), header.ReqGetPPList)
 }
 
-func ConnectToGatewayPP(pplist []*types.PeerInfo) bool {
+func ConnectToGatewayPP(ctx context.Context, pplist []*types.PeerInfo) bool {
 	for _, ppInfo := range pplist {
 		if ppInfo.NetworkAddress == setting.NetworkAddress {
-			peerList.DeletePPByNetworkAddress(ppInfo.NetworkAddress)
+			peerList.DeletePPByNetworkAddress(ctx, ppInfo.NetworkAddress)
 			continue
 		}
 		client.PPConn = client.NewClient(ppInfo.NetworkAddress, true)
 		if client.PPConn != nil {
 			return true
 		}
-		utils.DebugLog("failed to conn PP，delete:", ppInfo)
-		peerList.DeletePPByNetworkAddress(ppInfo.NetworkAddress)
+		pp.DebugLog(ctx, "failed to conn PP，delete:", ppInfo)
+		peerList.DeletePPByNetworkAddress(ctx, ppInfo.NetworkAddress)
 	}
 	return false
 }
@@ -93,42 +95,44 @@ func ConnectToGatewayPP(pplist []*types.PeerInfo) bool {
 //}
 
 //GetPPList will just get the list from
-func GetPPList() (list []*types.PeerInfo, total int64) {
-	list, total, _ = peerList.GetPPList()
+func GetPPList(ctx context.Context) (list []*types.PeerInfo, total int64) {
+	list, total, _ = peerList.GetPPList(ctx)
 	return
 }
 
 //SavePPList will save the target list to local list
-func SavePPList(target *protos.RspGetPPList) error {
-	return peerList.SavePPList(target)
+func SavePPList(ctx context.Context, target *protos.RspGetPPList) error {
+	return peerList.SavePPList(ctx, target)
 }
 
 //GetPPByP2pAddress
-func GetPPByP2pAddress(p2pAddr string) *types.PeerInfo {
-	return peerList.GetPPByP2pAddress(p2pAddr)
+func GetPPByP2pAddress(ctx context.Context, p2pAddr string) *types.PeerInfo {
+	return peerList.GetPPByP2pAddress(ctx, p2pAddr)
 }
 
 //UpdatePP will update one pp info to local list
-func UpdatePP(pp *types.PeerInfo) {
-	peerList.UpdatePP(pp)
+func UpdatePP(ctx context.Context, pp *types.PeerInfo) {
+	peerList.UpdatePP(ctx, pp)
 }
 
 //LantencyOfNextPp
-func LatencyOfNextPp() {
-	list, _, _ := peerList.GetPPList()
-	for _, peer := range list {
-		if peer.Latency == 0 {
-			StartLatencyCheckToPp(peer.NetworkAddress)
+func LatencyOfNextPp(ctx context.Context) func() {
+	return func() {
+		list, _, _ := peerList.GetPPList(ctx)
+		for _, peer := range list {
+			if peer.Latency == 0 {
+				StartLatencyCheckToPp(ctx, peer.NetworkAddress)
+			}
 		}
 	}
 }
 
 // StartLatencyCheckToPp
-func StartLatencyCheckToPp(NetworkAddr string) error {
+func StartLatencyCheckToPp(ctx context.Context, NetworkAddr string) error {
 	start := time.Now().UnixNano()
-	pb := &protos.ReqLatencyCheck {
-		HbType:       protos.HeartbeatType_LATENCY_CHECK_PP,
-		PingTime:     strconv.FormatInt(start, 10),
+	pb := &protos.ReqLatencyCheck{
+		HbType:   protos.HeartbeatType_LATENCY_CHECK_PP,
+		PingTime: strconv.FormatInt(start, 10),
 	}
 	data, err := proto.Marshal(pb)
 	if err != nil {
@@ -136,14 +140,14 @@ func StartLatencyCheckToPp(NetworkAddr string) error {
 	}
 
 	msg := &msg.RelayMsgBuf{
-		MSGHead: header.MakeMessageHeader(1, uint16(setting.Config.Version.AppVer), uint32(len(data)), header.ReqLatencyCheck, int64(0)),
+		MSGHead: header.MakeMessageHeader(1, uint16(setting.Config.Version.AppVer), uint32(len(data)), header.ReqLatencyCheck),
 		MSGData: data,
 	}
 
 	if client.ConnMap[NetworkAddr] != nil {
-		client.ConnMap[NetworkAddr].Write(msg)
+		client.ConnMap[NetworkAddr].Write(msg, ctx)
 	} else {
-		utils.DebugLog("new conn, connect and transfer")
+		pp.DebugLog(ctx, "new conn, connect and transfer")
 	}
 	return nil
 }

--- a/pp/peers/reconnect.go
+++ b/pp/peers/reconnect.go
@@ -1,12 +1,14 @@
 package peers
 
 import (
+	"context"
 	"math"
 	"math/rand"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/utils"
@@ -24,7 +26,7 @@ var (
 	retry               = 0
 )
 
-func ListenOffline() {
+func ListenOffline(ctx context.Context) {
 	for {
 		select {
 		case offline := <-client.OfflineChan:
@@ -32,39 +34,41 @@ func ListenOffline() {
 				if setting.IsPP {
 					utils.DebugLogf("SP %v is offline", offline.NetworkAddress)
 					setting.IsStartMining = false
-					reloadConnectSP()
-					GetSPList()
+					reloadConnectSP(ctx)()
+					GetSPList(ctx)()
 				}
 			} else {
-				peerList.PPDisconnected("", offline.NetworkAddress)
-				InitPPList()
+				peerList.PPDisconnected(ctx, "", offline.NetworkAddress)
+				InitPPList(ctx)
 			}
 		}
 	}
 }
 
-func reloadConnectSP() {
-	newConnection, err := ConnectToSP()
-	if newConnection {
-		RegisterToSP(true)
-		retry = 0
-		if setting.IsStartMining {
-			StartMining()
+func reloadConnectSP(ctx context.Context) func() {
+	return func() {
+		newConnection, err := ConnectToSP(ctx)
+		if newConnection {
+			RegisterToSP(ctx, true)
+			retry = 0
+			if setting.IsStartMining {
+				StartMining(ctx)
+			}
 		}
-	}
 
-	if err != nil {
-		//calc next reload interval
-		reloadSpInterval := minReloadSpInterval * int(math.Ceil(math.Pow(10, float64(retry))))
-		reloadSpInterval = int(math.Min(float64(reloadSpInterval), float64(maxReloadSpInterval)))
-		utils.Logf("couldn't connect to SP node. Retrying in %v seconds...", reloadSpInterval)
-		retry += 1
-		ppPeerClock.AddJobWithInterval(time.Duration(reloadSpInterval)*time.Second, reloadConnectSP)
+		if err != nil {
+			//calc next reload interval
+			reloadSpInterval := minReloadSpInterval * int(math.Ceil(math.Pow(10, float64(retry))))
+			reloadSpInterval = int(math.Min(float64(reloadSpInterval), float64(maxReloadSpInterval)))
+			pp.Logf(ctx, "couldn't connect to SP node. Retrying in %v seconds...", reloadSpInterval)
+			retry += 1
+			ppPeerClock.AddJobWithInterval(time.Duration(reloadSpInterval)*time.Second, reloadConnectSP(ctx))
+		}
 	}
 }
 
 // ConnectToSP Checks if there is a connection to an SP node. If it doesn't, it attempts to create one with a random SP node.
-func ConnectToSP() (newConnection bool, err error) {
+func ConnectToSP(ctx context.Context) (newConnection bool, err error) {
 	if client.SPConn != nil {
 		return false, nil
 	}
@@ -73,7 +77,7 @@ func ConnectToSP() (newConnection bool, err error) {
 	}
 
 	if optSpNetworkAddr, err := GetOptSPAndClear(); err == nil {
-		utils.DebugLog("reconnect to detected optimal SP ", optSpNetworkAddr)
+		pp.DebugLog(ctx, "reconnect to detected optimal SP ", optSpNetworkAddr)
 		client.SPConn = client.NewClient(optSpNetworkAddr, false)
 		if client.SPConn != nil {
 			return true, nil
@@ -93,10 +97,10 @@ func ConnectToSP() (newConnection bool, err error) {
 }
 
 // ConnectToOptSP connect if there is a detected optimal SP node.
-func ConfirmOptSP(spNetworkAddr string) {
-	utils.DebugLog("current sp ", client.SPConn.GetName(), " to be altered to new optimal SP ", spNetworkAddr)
+func ConfirmOptSP(ctx context.Context, spNetworkAddr string) {
+	pp.DebugLog(ctx, "current sp ", client.SPConn.GetName(), " to be altered to new optimal SP ", spNetworkAddr)
 	if client.SPConn.GetName() == spNetworkAddr {
-		utils.DebugLog("optimal SP already in connection, won't change SP")
+		pp.DebugLog(ctx, "optimal SP already in connection, won't change SP")
 		return
 	}
 	setOptSP(spNetworkAddr)

--- a/pp/peers/sp_peers.go
+++ b/pp/peers/sp_peers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/pp/types"
 
@@ -23,117 +24,118 @@ import (
 var bufferedSpConns = make([]*cf.ClientConn, 0)
 
 // SendMessage
-func SendMessage(conn core.WriteCloser, pb proto.Message, cmd string) error {
-	return SendResponseMessageWithReqId(conn, pb, cmd, int64(0))
-}
-
-func SendResponseMessageWithReqId(conn core.WriteCloser, pb proto.Message, cmd string, reqId int64) error {
+func SendMessage(ctx context.Context, conn core.WriteCloser, pb proto.Message, cmd string) error {
 	data, err := proto.Marshal(pb)
 
 	if err != nil {
-		utils.ErrorLog("error decoding")
+		pp.ErrorLog(ctx, "error decoding")
 		return errors.New("error decoding")
 	}
 	msg := &msg.RelayMsgBuf{
-		MSGHead: header.MakeMessageHeader(1, uint16(setting.Config.Version.AppVer), uint32(len(data)), cmd, reqId),
+		MSGHead: header.MakeMessageHeader(1, uint16(setting.Config.Version.AppVer), uint32(len(data)), cmd),
 		MSGData: data,
 	}
 	switch conn.(type) {
 	case *core.ServerConn:
-		return conn.(*core.ServerConn).Write(msg)
+		return conn.(*core.ServerConn).Write(msg, ctx)
 	case *cf.ClientConn:
-		return conn.(*cf.ClientConn).Write(msg)
+		return conn.(*cf.ClientConn).Write(msg, ctx)
 	default:
 		return errors.New("unknown connection type")
 	}
 }
 
-func SendMessageDirectToSPOrViaPP(pb proto.Message, cmd string) {
+func SendMessageDirectToSPOrViaPP(ctx context.Context, pb proto.Message, cmd string) {
 	if client.SPConn != nil {
-		SendMessage(client.SPConn, pb, cmd)
+		SendMessage(ctx, client.SPConn, pb, cmd)
 	} else {
-		SendMessage(client.PPConn, pb, cmd)
+		SendMessage(ctx, client.PPConn, pb, cmd)
 	}
 }
 
 // SendMessageToSPServer SendMessageToSPServer
-func SendMessageToSPServer(pb proto.Message, cmd string) {
-	_, err := ConnectToSP()
+func SendMessageToSPServer(ctx context.Context, pb proto.Message, cmd string) {
+	_, err := ConnectToSP(ctx)
 	if err != nil {
 		utils.ErrorLog(err)
 		return
 	}
 
-	SendMessage(client.SPConn, pb, cmd)
+	SendMessage(ctx, client.SPConn, pb, cmd)
 }
 
 // TransferSendMessageToPPServ
-func TransferSendMessageToPPServ(addr string, msgBuf *msg.RelayMsgBuf) {
+func TransferSendMessageToPPServ(ctx context.Context, addr string, msgBuf *msg.RelayMsgBuf) {
+	newCtx := core.CreateContextWithParentReqIdAsReqId(ctx)
 	if client.ConnMap[addr] != nil {
 
-		client.ConnMap[addr].Write(msgBuf)
+		client.ConnMap[addr].Write(msgBuf, newCtx)
 		utils.DebugLog("conn exist, transfer")
 	} else {
 		utils.DebugLog("new conn, connect and transfer")
-		client.NewClient(addr, false).Write(msgBuf)
+		client.NewClient(addr, false).Write(msgBuf, newCtx)
 	}
 }
 
-func TransferSendMessageToPPServByP2pAddress(p2pAddress string, msgBuf *msg.RelayMsgBuf) {
-	ppInfo := peerList.GetPPByP2pAddress(p2pAddress)
+func TransferSendMessageToPPServByP2pAddress(ctx context.Context, p2pAddress string, msgBuf *msg.RelayMsgBuf) {
+	ppInfo := peerList.GetPPByP2pAddress(ctx, p2pAddress)
 	if ppInfo == nil {
 		utils.ErrorLogf("PP %v missing from local ppList. Cannot transfer message due to missing network address", p2pAddress)
 		return
 	}
-	TransferSendMessageToPPServ(ppInfo.NetworkAddress, msgBuf)
+	TransferSendMessageToPPServ(ctx, ppInfo.NetworkAddress, msgBuf)
 }
 
 // transferSendMessageToSPServer
-func TransferSendMessageToSPServer(msg *msg.RelayMsgBuf) {
-	_, err := ConnectToSP()
+func TransferSendMessageToSPServer(ctx context.Context, msg *msg.RelayMsgBuf) {
+	_, err := ConnectToSP(ctx)
 	if err != nil {
 		utils.ErrorLog(err)
 		return
 	}
 
-	client.SPConn.Write(msg)
+	client.SPConn.Write(msg, ctx)
 }
 
 // ReqTransferSendSP
 func ReqTransferSendSP(ctx context.Context, conn core.WriteCloser) {
-	TransferSendMessageToSPServer(core.MessageFromContext(ctx))
+	TransferSendMessageToSPServer(ctx, core.MessageFromContext(ctx))
 }
 
 // transferSendMessageToClient
-func TransferSendMessageToClient(p2pAddress string, msgBuf *msg.RelayMsgBuf) {
-	pp := peerList.GetPPByP2pAddress(p2pAddress)
-	if pp != nil && pp.Status == types.PEER_CONNECTED {
-		utils.Log("transfer to netid = ", pp.NetId)
-		GetPPServer().Unicast(pp.NetId, msgBuf)
+func TransferSendMessageToClient(ctx context.Context, p2pAddress string, msgBuf *msg.RelayMsgBuf) {
+	ppNode := peerList.GetPPByP2pAddress(ctx, p2pAddress)
+	if ppNode != nil && ppNode.Status == types.PEER_CONNECTED {
+		pp.Log(ctx, "transfer to netid = ", ppNode.NetId)
+		GetPPServer().Unicast(ctx, ppNode.NetId, msgBuf)
 	} else {
-		utils.DebugLog("waller ===== ", p2pAddress)
+		pp.DebugLog(ctx, "waller ===== ", p2pAddress)
 	}
 }
 
 // GetMyNodeStatusFromSP P node get node status
-func GetPPStatusFromSP() {
-	utils.DebugLog("SendMessage(client.SPConn, req, header.ReqGetPPStatus)")
-	SendMessageToSPServer(requests.ReqGetPPStatusData(false), header.ReqGetPPStatus)
+func GetPPStatusFromSP(ctx context.Context) {
+	pp.DebugLog(ctx, "SendMessage(client.SPConn, req, header.ReqGetPPStatus)")
+	SendMessageToSPServer(ctx, requests.ReqGetPPStatusData(false), header.ReqGetPPStatus)
 }
 
 // GetMyNodeStatusFromSP P node get node status
-func GetPPStatusInitPPList() {
-	utils.DebugLog("SendMessage(client.SPConn, req, header.ReqGetPPStatus)")
-	SendMessageToSPServer(requests.ReqGetPPStatusData(true), header.ReqGetPPStatus)
+func GetPPStatusInitPPList(ctx context.Context) func() {
+	return func() {
+		pp.DebugLog(ctx, "SendMessage(client.SPConn, req, header.ReqGetPPStatus)")
+		SendMessageToSPServer(ctx, requests.ReqGetPPStatusData(true), header.ReqGetPPStatus)
+	}
 }
 
 // GetSPList node get spList
-func GetSPList() {
-	utils.DebugLog("SendMessage(client.SPConn, req, header.ReqGetSPList)")
-	SendMessageToSPServer(requests.ReqGetSPlistData(), header.ReqGetSPList)
+func GetSPList(ctx context.Context) func() {
+	return func() {
+		pp.DebugLog(ctx, "SendMessage(client.SPConn, req, header.ReqGetSPList)")
+		SendMessageToSPServer(ctx, requests.ReqGetSPlistData(), header.ReqGetSPList)
+	}
 }
 
-func SendLatencyCheckMessageToSPList() {
+func SendLatencyCheckMessageToSPList(ctx context.Context) {
 	utils.DebugLogf("[SP_LATENCY_CHECK] SendHeartbeatToSPList, num of SPs: %v", len(setting.Config.SPList))
 	if len(setting.Config.SPList) < 2 {
 		utils.ErrorLog("there are not enough SP nodes in the config file")
@@ -141,11 +143,11 @@ func SendLatencyCheckMessageToSPList() {
 	}
 	for i := 0; i < len(setting.Config.SPList); i++ {
 		selectedSP := setting.Config.SPList[i]
-		checkSingleSpLatency(selectedSP.NetworkAddress, false)
+		checkSingleSpLatency(ctx, selectedSP.NetworkAddress, false)
 	}
 }
 
-func checkSingleSpLatency(server string, heartbeat bool) {
+func checkSingleSpLatency(ctx context.Context, server string, heartbeat bool) {
 	if client.SPConn == nil {
 		utils.DebugLog("SP latency check skipped until connection to SP is recovered")
 		return
@@ -167,7 +169,7 @@ func checkSingleSpLatency(server string, heartbeat bool) {
 			NetworkAddressSp: server,
 			PingTime:         strconv.FormatInt(start, 10),
 		}
-		SendMessage(spConn, pb, header.ReqLatencyCheck)
+		SendMessage(ctx, spConn, pb, header.ReqLatencyCheck)
 		if client.GetConnectionName(client.SPConn) != server {
 			bufferedSpConns = append(bufferedSpConns, spConn)
 		}
@@ -182,12 +184,12 @@ func ClearBufferedSpConns() {
 	bufferedSpConns = make([]*cf.ClientConn, 0)
 }
 
-func ScheduleReloadSPlist(future time.Duration) {
+func ScheduleReloadSPlist(ctx context.Context, future time.Duration) {
 	utils.DebugLog("scheduled to get sp-list after: ", future.Seconds(), "second")
-	ppPeerClock.AddJobWithInterval(future, GetSPList)
+	ppPeerClock.AddJobWithInterval(future, GetSPList(ctx))
 }
 
-func ScheduleReloadPPStatus(future time.Duration) {
+func ScheduleReloadPPStatus(ctx context.Context, future time.Duration) {
 	utils.DebugLog("scheduled to get pp status from sp after: ", future.Seconds(), "second")
-	ppPeerClock.AddJobWithInterval(future, GetPPStatusInitPPList)
+	ppPeerClock.AddJobWithInterval(future, GetPPStatusInitPPList(ctx))
 }

--- a/pp/peers/start.go
+++ b/pp/peers/start.go
@@ -1,62 +1,64 @@
 package peers
 
 import (
+	"context"
 	"path/filepath"
 
 	"github.com/stratosnet/sds/msg/header"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/requests"
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/utils"
 )
 
-func StartPP(registerFn func()) {
+func StartPP(ctx context.Context, registerFn func()) {
 	GetNetworkAddress()
 	peerList.Init(setting.NetworkAddress, filepath.Join(setting.Config.PPListDir, "pp-list"))
 	//todo: register func call shouldn't be in peers package
 	registerFn()
-	go StartListenServer(setting.Config.Port)
-	GetSPList()
-	GetPPStatusInitPPList()
+	go StartListenServer(ctx, setting.Config.Port)
+	GetSPList(ctx)()
+	GetPPStatusInitPPList(ctx)()
 	//go SendLatencyCheckMessageToSPList()
-	StartPpLatencyCheck()
-	StartStatusReportToSP()
-	ListenOffline()
+	StartPpLatencyCheck(ctx)
+	StartStatusReportToSP(ctx)
+	ListenOffline(ctx)
 }
 
-func InitPeer(registerFn func()) {
+func InitPeer(ctx context.Context, registerFn func()) {
 	// TODO: To make sure this InitPeer method is correctly called and work as expected
 	utils.DebugLog("InitPeer")
 	//todo: register func call shouldn't be in peers package
 	registerFn()
-	GetSPList()
-	GetPPStatusInitPPList()
+	GetSPList(ctx)()
+	GetPPStatusInitPPList(ctx)()
 	//go SendLatencyCheckMessageToSPList()
-	go ListenOffline()
+	go ListenOffline(ctx)
 }
 
-func RegisterToSP(toSP bool) {
+func RegisterToSP(ctx context.Context, toSP bool) {
 	if toSP {
-		SendMessageToSPServer(requests.ReqRegisterData(), header.ReqRegister)
-		utils.Log("SendMessage(conn, req, header.ReqRegister) to SP")
+		SendMessageToSPServer(ctx, requests.ReqRegisterData(), header.ReqRegister)
+		pp.Log(ctx, "SendMessage(conn, req, header.ReqRegister) to SP")
 	} else {
-		SendMessage(client.PPConn, requests.ReqRegisterData(), header.ReqRegister)
-		utils.Log("SendMessage(conn, req, header.ReqRegister) to PP")
+		SendMessage(ctx, client.PPConn, requests.ReqRegisterData(), header.ReqRegister)
+		pp.Log(ctx, "SendMessage(conn, req, header.ReqRegister) to PP")
 	}
 }
 
-func StartMining() {
+func StartMining(ctx context.Context) {
 	if setting.CheckLogin() {
 		if setting.IsPP && !setting.IsLoginToSP {
-			utils.DebugLog("Bond to SP and start mining")
-			SendMessageToSPServer(requests.ReqRegisterData(), header.ReqRegister)
+			pp.DebugLog(ctx, "Bond to SP and start mining")
+			SendMessageToSPServer(ctx, requests.ReqRegisterData(), header.ReqRegister)
 		} else if setting.IsPP && !setting.IsStartMining {
 			utils.DebugLog("Sending ReqMining message to SP")
-			SendMessageToSPServer(requests.ReqMiningData(), header.ReqMining)
+			SendMessageToSPServer(ctx, requests.ReqMiningData(), header.ReqMining)
 		} else if setting.IsStartMining {
-			utils.Log("mining already started")
+			pp.Log(ctx, "mining already started")
 		} else {
-			utils.Log("register as miner first")
+			pp.Log(ctx, "register as miner first")
 		}
 	}
 }

--- a/pp/requests/requests.go
+++ b/pp/requests/requests.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stratosnet/sds/msg"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/setting"
 	"github.com/stratosnet/sds/pp/task"
@@ -58,7 +59,7 @@ func ReqRegisterDataTR(target *protos.ReqRegister) *msg.RelayMsgBuf {
 		utils.ErrorLog(err)
 	}
 	return &msg.RelayMsgBuf{
-		MSGHead: PPMsgHeaderWithoutReqId(data, header.ReqRegister),
+		MSGHead: PPMsgHeader(data, header.ReqRegister),
 		MSGData: data,
 	}
 }
@@ -133,7 +134,7 @@ func RequestUploadFile(fileName, fileHash string, fileSize uint64, reqID, ownerW
 
 	p2pFileString := GetUploadFileSignMessage(setting.WalletAddress, setting.P2PAddress, ownerWalletAddress, fileHash, header.ReqUploadFile)
 
-	file.SaveRemoteFileHash(fileHash, "rpc:" + fileName, fileSize)
+	file.SaveRemoteFileHash(fileHash, "rpc:"+fileName, fileSize)
 
 	req := &protos.ReqUploadFile{
 		FileInfo: &protos.FileInfo{
@@ -174,20 +175,20 @@ func RequestUploadFile(fileName, fileHash string, fileSize uint64, reqID, ownerW
 }
 
 // RequestUploadFileData RequestUploadFileData, ownerWalletAddress can be either pp node's walletAddr or file owner's walletAddr
-func RequestUploadFileData(paths, storagePath, reqID, ownerWalletAddress string, isCover, isVideoStream, isEncrypted bool) *protos.ReqUploadFile {
+func RequestUploadFileData(ctx context.Context, paths, storagePath, reqID, ownerWalletAddress string, isCover, isVideoStream, isEncrypted bool) *protos.ReqUploadFile {
 	info := file.GetFileInfo(paths)
 	if info == nil {
-		utils.ErrorLog("wrong filePath")
+		pp.ErrorLog(ctx, "wrong filePath")
 		return nil
 	}
 	fileName := info.Name()
-	utils.Log("fileName~~~~~~~~~~~~~~~~~~~~~~~~", fileName)
+	pp.Log(ctx, "fileName~~~~~~~~~~~~~~~~~~~~~~~~", fileName)
 	encryptionTag := ""
 	if isEncrypted {
 		encryptionTag = utils.GetRandomString(8)
 	}
 	fileHash := file.GetFileHash(paths, encryptionTag)
-	utils.Log("fileHash~~~~~~~~~~~~~~~~~~~~~~", fileHash)
+	pp.Log(ctx, "fileHash~~~~~~~~~~~~~~~~~~~~~~", fileHash)
 
 	p2pFileString := GetUploadFileSignMessage(setting.WalletAddress, setting.P2PAddress, ownerWalletAddress, fileHash, header.ReqUploadFile)
 
@@ -218,16 +219,16 @@ func RequestUploadFileData(paths, storagePath, reqID, ownerWalletAddress string,
 	if isVideoStream {
 		duration, err := file.GetVideoDuration(paths)
 		if err != nil {
-			utils.ErrorLog("Failed to get the length of the video: ", err)
+			pp.ErrorLog(ctx, "Failed to get the length of the video: ", err)
 			return nil
 		}
 		req.FileInfo.Duration = duration
 	}
 	p2pFileHash := []byte(p2pFileString)
-	utils.DebugLogf("setting.WalletAddress + fileHash : %v", hex.EncodeToString(p2pFileHash))
+	pp.DebugLogf(ctx, "setting.WalletAddress + fileHash : %v", hex.EncodeToString(p2pFileHash))
 
 	if !ed25519.Verify(setting.P2PPublicKey, p2pFileHash, req.Sign) {
-		utils.ErrorLog("ed25519 verification failed")
+		pp.ErrorLog(ctx, "ed25519 verification failed")
 		return nil
 	}
 
@@ -252,7 +253,7 @@ func RequestDownloadFile(fileHash, walletAddr, reqId string, shareRequest *proto
 	}
 
 	// download file uses fileHash + fileReqId as the key
-	file.SaveRemoteFileHash(fileHash + fileReqId, "rpc:", 0)
+	file.SaveRemoteFileHash(fileHash+fileReqId, "rpc:", 0)
 
 	// path: mesh network address
 	sdmPath := "sdm://" + walletAddr + "/" + fileHash
@@ -492,7 +493,7 @@ func ReqTransferDownloadData(notice *protos.ReqFileSliceBackupNotice, newPpP2pAd
 		utils.ErrorLog(err)
 	}
 	return &msg.RelayMsgBuf{
-		MSGHead: PPMsgHeaderWithoutReqId(data, header.ReqTransferDownload),
+		MSGHead: PPMsgHeader(data, header.ReqTransferDownload),
 		MSGData: data,
 	}
 }
@@ -515,7 +516,7 @@ func ReqReportTaskBPData(taskID string, traffic uint64) *msg.RelayMsgBuf {
 		utils.ErrorLog(err)
 	}
 	return &msg.RelayMsgBuf{
-		MSGHead: PPMsgHeaderWithoutReqId(data, header.ReqReportTaskBP),
+		MSGHead: PPMsgHeader(data, header.ReqReportTaskBP),
 		MSGData: data,
 	}
 }
@@ -631,7 +632,7 @@ func RspDownloadSliceWrong(target *protos.RspDownloadSliceWrong) *msg.RelayMsgBu
 		utils.ErrorLog(err)
 	}
 	return &msg.RelayMsgBuf{
-		MSGHead: PPMsgHeaderWithoutReqId(data, header.ReqDownloadSlice),
+		MSGHead: PPMsgHeader(data, header.ReqDownloadSlice),
 		MSGData: data,
 	}
 }
@@ -687,7 +688,7 @@ func ReqShareFileData(reqID, fileHash, pathHash, walletAddr string, isPrivate bo
 	}
 }
 
-func ReqDeleteShareData(reqID, shareID,walletAddr string) *protos.ReqDeleteShare {
+func ReqDeleteShareData(reqID, shareID, walletAddr string) *protos.ReqDeleteShare {
 	return &protos.ReqDeleteShare{
 		ReqId:         reqID,
 		P2PAddress:    setting.P2PAddress,
@@ -765,13 +766,13 @@ func ReqNodeStatusData() *protos.ReqReportNodeStatus {
 }
 
 // PPMsgHeader
-func PPMsgHeaderWithoutReqId(data []byte, head string) header.MessageHead {
-	return header.MakeMessageHeader(1, uint16(setting.Config.Version.AppVer), uint32(len(data)), head, utils.ZeroId())
+func PPMsgHeader(data []byte, head string) header.MessageHead {
+	return header.MakeMessageHeader(1, uint16(setting.Config.Version.AppVer), uint32(len(data)), head)
 }
 
 func UnmarshalData(ctx context.Context, target interface{}) bool {
 	msgBuf := core.MessageFromContext(ctx)
-	utils.DebugLogf("Received message type = %v msgBuf len = %v", reflect.TypeOf(target), len(msgBuf.MSGData))
+	pp.DebugLogf(ctx, "Received message type = %v msgBuf len = %v", reflect.TypeOf(target), len(msgBuf.MSGData))
 	return UnmarshalMessageData(msgBuf.MSGData, target)
 }
 

--- a/pp/serv/account.go
+++ b/pp/serv/account.go
@@ -1,11 +1,13 @@
 package serv
 
 import (
+	"context"
 	"errors"
 	"io/fs"
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/event"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/setting"
@@ -15,11 +17,11 @@ import (
 )
 
 // CreateWallet
-func CreateWallet(password, name, mnemonic, hdPath string) string {
+func CreateWallet(ctx context.Context, password, name, mnemonic, hdPath string) string {
 	if mnemonic == "" {
 		newMnemonic, err := utils.NewMnemonic()
 		if err != nil {
-			utils.ErrorLog("Couldn't generate new mnemonic", err)
+			pp.ErrorLog(ctx, "Couldn't generate new mnemonic", err)
 			return ""
 		}
 		mnemonic = newMnemonic
@@ -27,24 +29,24 @@ func CreateWallet(password, name, mnemonic, hdPath string) string {
 	account, err := utils.CreateWallet(setting.Config.AccountDir, name, password, types.StratosBech32Prefix,
 		mnemonic, "", hdPath)
 	if utils.CheckError(err) {
-		utils.ErrorLog("CreateWallet error", err)
+		pp.ErrorLog(ctx, "CreateWallet error", err)
 		return ""
 	}
 	setting.WalletAddress, err = account.ToBech(types.StratosBech32Prefix)
 	if utils.CheckError(err) {
-		utils.ErrorLog("CreateWallet error", err)
+		pp.ErrorLog(ctx, "CreateWallet error", err)
 		return ""
 	}
 	if setting.WalletAddress != "" {
 		setting.SetConfig("wallet_address", setting.WalletAddress)
 	}
-	getPublicKey(filepath.Join(setting.Config.AccountDir, setting.WalletAddress+".json"), password)
+	getPublicKey(ctx, filepath.Join(setting.Config.AccountDir, setting.WalletAddress+".json"), password)
 	utils.Log("Create account success ,", setting.WalletAddress)
 	return setting.WalletAddress
 }
 
 // GetWalletAddress
-func GetWalletAddress() error {
+func GetWalletAddress(ctx context.Context) error {
 	files, err := ioutil.ReadDir(setting.Config.AccountDir)
 
 	if len(files) == 0 {
@@ -63,7 +65,7 @@ func GetWalletAddress() error {
 			continue
 		}
 		utils.Log(info.Name())
-		if getPublicKey(filepath.Join(setting.Config.AccountDir, fileName), password) {
+		if getPublicKey(ctx, filepath.Join(setting.Config.AccountDir, fileName), password) {
 			setting.WalletAddress = walletAddress
 			return nil
 		}
@@ -72,27 +74,27 @@ func GetWalletAddress() error {
 	return errors.New("could not find the account file corresponds to the configured wallet address")
 }
 
-func getPublicKey(filePath, password string) bool {
+func getPublicKey(ctx context.Context, filePath, password string) bool {
 	keyjson, err := ioutil.ReadFile(filePath)
 	if utils.CheckError(err) {
-		utils.ErrorLog("getPublicKey ioutil.ReadFile", err)
+		pp.ErrorLog(ctx, "getPublicKey ioutil.ReadFile", err)
 		return false
 	}
 	key, err := utils.DecryptKey(keyjson, password)
 
 	if utils.CheckError(err) {
-		utils.ErrorLog("getPublicKey DecryptKey", err)
+		pp.ErrorLog(ctx, "getPublicKey DecryptKey", err)
 		return false
 	}
 	setting.WalletPrivateKey = key.PrivateKey
 	setting.WalletPublicKey = secp256k1.PrivKeyToPubKey(key.PrivateKey).Bytes()
-	utils.DebugLog("publicKey", setting.WalletPublicKey)
-	utils.Log("unlock wallet successfully ", setting.WalletAddress)
+	pp.DebugLog(ctx, "publicKey", setting.WalletPublicKey)
+	pp.Log(ctx, "unlock wallet successfully ", setting.WalletAddress)
 	return true
 }
 
 // Wallets get all wallets
-func Wallets() []string {
+func Wallets(ctx context.Context) []string {
 	files, _ := ioutil.ReadDir(setting.Config.AccountDir)
 	var wallets []string
 	for _, file := range files {
@@ -103,18 +105,18 @@ func Wallets() []string {
 	}
 
 	if len(wallets) == 0 {
-		utils.Log("no wallet exists yet")
+		pp.Log(ctx, "no wallet exists yet")
 	} else {
 		for _, wallet := range wallets {
-			utils.Log(wallet)
+			pp.Log(ctx, wallet)
 		}
 	}
 	return wallets
 }
 
 // Login
-func Login(walletAddress, password string) error {
-	files, err := GetWallets(walletAddress, password)
+func Login(ctx context.Context, walletAddress, password string) error {
+	files, err := GetWallets(ctx, walletAddress, password)
 	if err != nil {
 		return err
 	}
@@ -124,30 +126,30 @@ func Login(walletAddress, password string) error {
 			continue
 		}
 		utils.Log(info.Name())
-		if getPublicKey(filepath.Join(setting.Config.AccountDir, fileName), password) {
+		if getPublicKey(ctx, filepath.Join(setting.Config.AccountDir, fileName), password) {
 			setting.SetConfig("wallet_address", walletAddress)
 			setting.SetConfig("wallet_password", password)
 			setting.WalletAddress = walletAddress
-			peers.InitPeer(event.RegisterEventHandle)
+			peers.InitPeer(ctx, event.RegisterEventHandle)
 			return nil
 		}
-		utils.ErrorLog("wrong password")
+		pp.ErrorLog(ctx, "wrong password")
 		return errors.New("wrong password")
 	}
-	utils.ErrorLog("wrong walletAddress or password")
+	pp.ErrorLog(ctx, "wrong walletAddress or password")
 	return errors.New("wrong walletAddress or password")
 }
 
-func GetWallets(walletAddress string, password string) ([]fs.FileInfo, error) {
-	utils.DebugLog("walletAddress = ", walletAddress)
+func GetWallets(ctx context.Context, walletAddress string, password string) ([]fs.FileInfo, error) {
+	pp.DebugLog(ctx, "walletAddress = ", walletAddress)
 	if walletAddress == "" {
-		utils.ErrorLog("please input wallet address")
+		pp.ErrorLog(ctx, "please input wallet address")
 		return nil, errors.New("please input wallet address")
 	}
 
 	files, _ := ioutil.ReadDir(setting.Config.AccountDir)
 	if len(files) == 0 {
-		utils.ErrorLog("wrong account or password")
+		pp.ErrorLog(ctx, "wrong account or password")
 		return nil, errors.New("wrong account or password")
 	}
 	return files, nil

--- a/pp/serv/monitor.go
+++ b/pp/serv/monitor.go
@@ -194,7 +194,7 @@ func (api *monitorApi) GetPeerList(param ParamGetPeerList) (*PeerListResult, err
 		return nil, errors.New("client hasn't subscribed to the service")
 	}
 
-	pl, t := peers.GetPPList()
+	pl, t := peers.GetPPList(context.Background())
 	var peer PeerInfo
 	var peers []PeerInfo
 	var i int64

--- a/pp/serv/rpc_log_service.go
+++ b/pp/serv/rpc_log_service.go
@@ -32,7 +32,7 @@ func (l rpcWriter) Write(p []byte) (n int, err error) {
 }
 
 func (s *rpcLogService) CleanUp() {
-	utils.MyLogger.ClearRpcLogger()
+	utils.ClearRpcLogger()
 }
 
 func (s *rpcLogService) LogSubscription(ctx context.Context) (*rpc.Subscription, error) {
@@ -42,7 +42,7 @@ func (s *rpcLogService) LogSubscription(ctx context.Context) (*rpc.Subscription,
 	}
 
 	subscription := notifier.CreateSubscription()
-	utils.MyLogger.SetRpcLogger(rpcWriter{
+	utils.SetRpcLogger(rpcWriter{
 		notifier:     notifier,
 		subscription: subscription,
 	})

--- a/pp/serv/serv.go
+++ b/pp/serv/serv.go
@@ -1,6 +1,7 @@
 package serv
 
 import (
+	"context"
 	"errors"
 	"strconv"
 
@@ -12,12 +13,13 @@ import (
 )
 
 const (
-	DefaultHTTPHost    = "0.0.0.0"   // Default host: INADDR_ANY
-	DefaultHTTPPort    = 8235        // Default TCP port for the HTTP RPC server
+	DefaultHTTPHost = "0.0.0.0" // Default host: INADDR_ANY
+	DefaultHTTPPort = 8235      // Default TCP port for the HTTP RPC server
 )
 
 func Start() {
-	err := GetWalletAddress()
+	ctx := context.Background()
+	err := GetWalletAddress(ctx)
 	if err != nil {
 		utils.ErrorLog(err)
 		return
@@ -41,7 +43,7 @@ func Start() {
 		return
 	}
 
-	peers.StartPP(event.RegisterEventHandle)
+	peers.StartPP(ctx, event.RegisterEventHandle)
 }
 
 func startIPC() error {
@@ -94,7 +96,7 @@ func startHttpRPC() error {
 	}
 
 	if err := rpcServer.start(); err != nil {
-  		return err
+		return err
 	}
 
 	return nil

--- a/pp/serv/terminal_cmd.go
+++ b/pp/serv/terminal_cmd.go
@@ -1,18 +1,20 @@
 package serv
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strconv"
 
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/pp/event"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/peers"
 	"github.com/stratosnet/sds/pp/setting"
-	"github.com/stratosnet/sds/pp/types"
 	"github.com/stratosnet/sds/pp/task"
+	"github.com/stratosnet/sds/pp/types"
 	"github.com/stratosnet/sds/utils"
 )
 
@@ -32,12 +34,14 @@ func TerminalAPI() *terminalCmd {
 }
 
 func (api *terminalCmd) Wallets(param []string) (CmdResult, error) {
-	Wallets()
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	Wallets(ctx)
 	return CmdResult{Msg: ""}, nil
 }
 
 func (api *terminalCmd) Getoz(param []string) (CmdResult, error) {
-	files, err := GetWallets(param[0], param[1])
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	files, err := GetWallets(ctx, param[0], param[1])
 
 	if err != nil {
 		fmt.Println(err)
@@ -48,46 +52,50 @@ func (api *terminalCmd) Getoz(param []string) (CmdResult, error) {
 		if info.Name() == ".placeholder" || info.Name() != fileName {
 			continue
 		}
-		utils.Log("find file: " + filepath.Join(setting.Config.AccountDir, fileName))
+		pp.Log(ctx, "find file: "+filepath.Join(setting.Config.AccountDir, fileName))
 		keyjson, err := ioutil.ReadFile(filepath.Join(setting.Config.AccountDir, fileName))
 		if utils.CheckError(err) {
-			utils.ErrorLog("getPublicKey ioutil.ReadFile", err)
+			pp.ErrorLog(ctx, "getPublicKey ioutil.ReadFile", err)
 			fmt.Println(err)
 			return CmdResult{Msg: ""}, err
 		}
 		_, err = utils.DecryptKey(keyjson, param[1])
 
 		if utils.CheckError(err) {
-			utils.ErrorLog("getPublicKey DecryptKey", err)
+			pp.ErrorLog(ctx, "getPublicKey DecryptKey", err)
 			return CmdResult{Msg: ""}, err
 		}
-		if err := event.GetWalletOz(param[0], task.LOCAL_REQID); err != nil {
+		if err := event.GetWalletOz(ctx, param[0], task.LOCAL_REQID); err != nil {
 			return CmdResult{Msg: ""}, err
 		}
 		return CmdResult{Msg: DefaultMsg}, nil
 	}
 
-	utils.ErrorLogf("Wallet %v does not exists", param[0])
+	pp.ErrorLogf(ctx, "Wallet %v does not exists", param[0])
 	return CmdResult{Msg: ""}, err
 }
 
 func (api *terminalCmd) NewWallet(param []string) (CmdResult, error) {
-	CreateWallet(param[0], param[1], param[2], param[3])
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	CreateWallet(ctx, param[0], param[1], param[2], param[3])
 	return CmdResult{Msg: ""}, nil
 }
 
 func (api *terminalCmd) Login(param []string) (CmdResult, error) {
-	err := Login(param[0], param[1])
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	err := Login(ctx, param[0], param[1])
 	return CmdResult{Msg: ""}, err
 }
 
 func (api *terminalCmd) Start(param []string) (CmdResult, error) {
-	peers.StartMining()
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	peers.StartMining(ctx)
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 
 func (api *terminalCmd) RegisterPP(param []string) (CmdResult, error) {
-	event.RegisterNewPP()
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	event.RegisterNewPP(ctx)
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 
@@ -117,7 +125,8 @@ func (api *terminalCmd) Activate(param []string) (CmdResult, error) {
 		return CmdResult{Msg: "register as a PP node first"}, nil
 	}
 
-	if err := event.Activate(amount, fee, gas); err != nil {
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	if err := event.Activate(ctx, amount, fee, gas); err != nil {
 		return CmdResult{Msg: ""}, err
 	}
 	return CmdResult{Msg: DefaultMsg}, nil
@@ -159,14 +168,16 @@ func (api *terminalCmd) UpdateStake(param []string) (CmdResult, error) {
 		return CmdResult{Msg: "register as a PP node first"}, nil
 	}
 
-	if err := event.UpdateStake(stakeDelta, fee, gas, incrStake); err != nil {
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	if err := event.UpdateStake(ctx, stakeDelta, fee, gas, incrStake); err != nil {
 		return CmdResult{Msg: ""}, err
 	}
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 
 func (api *terminalCmd) Status(param []string) (CmdResult, error) {
-	peers.GetPPStatusFromSP()
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	peers.GetPPStatusFromSP(ctx)
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 
@@ -188,7 +199,8 @@ func (api *terminalCmd) Deactivate(param []string) (CmdResult, error) {
 		return CmdResult{Msg: "The node is already inactive"}, nil
 	}
 
-	if err := event.Deactivate(fee, gas); err != nil {
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	if err := event.Deactivate(ctx, fee, gas); err != nil {
 		return CmdResult{Msg: ""}, err
 	}
 	return CmdResult{Msg: DefaultMsg}, nil
@@ -212,7 +224,8 @@ func (api *terminalCmd) Prepay(param []string) (CmdResult, error) {
 		return CmdResult{Msg: ""}, errors.New("invalid gas param. Should be an integerr")
 	}
 
-	if err := event.Prepay(amount, fee, gas); err != nil {
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	if err := event.Prepay(ctx, amount, fee, gas); err != nil {
 		return CmdResult{Msg: ""}, err
 	}
 	return CmdResult{Msg: DefaultMsg}, nil
@@ -227,7 +240,9 @@ func (api *terminalCmd) Upload(param []string) (CmdResult, error) {
 		isEncrypted = true
 	}
 	pathStr := file.EscapePath(param[0:1])
-	event.RequestUploadFile(pathStr, "", isEncrypted, nil)
+
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	event.RequestUploadFile(ctx, pathStr, "", isEncrypted, nil)
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 
@@ -236,7 +251,8 @@ func (api *terminalCmd) UploadStream(param []string) (CmdResult, error) {
 		return CmdResult{}, errors.New("input upload file path")
 	}
 	pathStr := file.EscapePath(param)
-	event.RequestUploadStream(pathStr, "", nil)
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	event.RequestUploadStream(ctx, pathStr, "", nil)
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 
@@ -244,19 +260,21 @@ func (api *terminalCmd) BackupStatus(param []string) (CmdResult, error) {
 	if len(param) == 0 {
 		return CmdResult{}, errors.New("input file hash")
 	}
-	event.ReqBackupStatus(param[0])
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	event.ReqBackupStatus(ctx, param[0])
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 
 func (api *terminalCmd) List(param []string) (CmdResult, error) {
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
 	if len(param) == 0 {
-		event.FindFileList("", setting.WalletAddress, 0, "", "", 0, true, nil)
-	}else {
+		event.FindFileList(ctx, "", setting.WalletAddress, 0, "", "", 0, true, nil)
+	} else {
 		pageId, err := strconv.ParseUint(param[0], 10, 64)
 		if err == nil {
-			event.FindFileList("", setting.WalletAddress, pageId, "", "", 0, true, nil)
-		}else {
-			event.FindFileList(param[0], setting.WalletAddress, 0, "", "", 0, true, nil)
+			event.FindFileList(ctx, "", setting.WalletAddress, pageId, "", "", 0, true, nil)
+		} else {
+			event.FindFileList(ctx, param[0], setting.WalletAddress, 0, "", "", 0, true, nil)
 		}
 	}
 	return CmdResult{Msg: DefaultMsg}, nil
@@ -270,7 +288,8 @@ func (api *terminalCmd) Download(param []string) (CmdResult, error) {
 	if len(param) == 2 {
 		saveAs = param[1]
 	}
-	event.GetFileStorageInfo(param[0], "", task.LOCAL_REQID, setting.WalletAddress, saveAs, false, nil)
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	event.GetFileStorageInfo(ctx, param[0], "", task.LOCAL_REQID, setting.WalletAddress, saveAs, false, nil)
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 
@@ -282,7 +301,8 @@ func (api *terminalCmd) DeleteFn(param []string) (CmdResult, error) {
 	if !utils.VerifyHash(param[0]) {
 		return CmdResult{}, errors.New("input correct file hash")
 	}
-	event.DeleteFile(param[0], "", nil)
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	event.DeleteFile(ctx, param[0], "", nil)
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 
@@ -325,10 +345,11 @@ func (api *terminalCmd) SharePath(param []string) (CmdResult, error) {
 	if private == 1 {
 		isPrivate = true
 	}
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
 	// if len(str1) == setting.FILEHASHLEN { //
 	// 	event.GetReqShareFile("", str1, "", int64(time), isPrivate, nil)
 	// } else {
-	event.GetReqShareFile("", "", param[0], setting.WalletAddress, int64(time), isPrivate, nil)
+	event.GetReqShareFile(ctx, "", "", param[0], setting.WalletAddress, int64(time), isPrivate, nil)
 	// }
 	return CmdResult{Msg: DefaultMsg}, nil
 }
@@ -350,7 +371,8 @@ func (api *terminalCmd) ShareFile(param []string) (CmdResult, error) {
 	if private == 1 {
 		isPrivate = true
 	}
-	event.GetReqShareFile("", param[0], "", setting.WalletAddress,int64(time), isPrivate, nil)
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	event.GetReqShareFile(ctx, "", param[0], "", setting.WalletAddress, int64(time), isPrivate, nil)
 	// if len(str1) == setting.FILEHASHLEN { //
 	// 	event.GetReqShareFile("", str1, "", int64(time), isPrivate, nil)
 	// } else {
@@ -359,14 +381,15 @@ func (api *terminalCmd) ShareFile(param []string) (CmdResult, error) {
 }
 
 func (api *terminalCmd) AllShare(param []string) (CmdResult, error) {
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
 	if len(param) < 1 {
-		event.GetAllShareLink("", setting.WalletAddress, 0, nil)
-	}else {
+		event.GetAllShareLink(ctx, "", setting.WalletAddress, 0, nil)
+	} else {
 		page, err := strconv.ParseUint(param[0], 10, 64)
 		if err != nil {
 			return CmdResult{Msg: ""}, errors.New("invalid page id.")
 		}
-		event.GetAllShareLink("", setting.WalletAddress, page, nil)
+		event.GetAllShareLink(ctx, "", setting.WalletAddress, page, nil)
 	}
 
 	return CmdResult{Msg: DefaultMsg}, nil
@@ -376,18 +399,20 @@ func (api *terminalCmd) CancelShare(param []string) (CmdResult, error) {
 	if len(param) < 1 {
 		return CmdResult{Msg: ""}, errors.New("input share id")
 	}
-	event.DeleteShare(param[0], "", setting.WalletAddress, nil)
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	event.DeleteShare(ctx, param[0], "", setting.WalletAddress, nil)
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 
 func (api *terminalCmd) GetShareFile(param []string) (CmdResult, error) {
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
 	if len(param) < 1 {
 		return CmdResult{Msg: ""}, errors.New("input share link and retrieval secret key(if any)")
 	}
 	if len(param) < 2 {
-		event.GetShareFile(param[0], "", "", task.LOCAL_REQID, setting.WalletAddress, nil)
+		event.GetShareFile(ctx, param[0], "", "", task.LOCAL_REQID, setting.WalletAddress, nil)
 	} else {
-		event.GetShareFile(param[0], param[1], "", task.LOCAL_REQID, setting.WalletAddress, nil)
+		event.GetShareFile(ctx, param[0], param[1], "", task.LOCAL_REQID, setting.WalletAddress, nil)
 	}
 
 	return CmdResult{Msg: DefaultMsg}, nil
@@ -405,7 +430,8 @@ func (api *terminalCmd) PausePut(param []string) (CmdResult, error) {
 	if len(param) < 1 {
 		return CmdResult{Msg: ""}, errors.New("input file hash of the pause")
 	}
-	event.UploadPause(param[0], "", nil)
+	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	event.UploadPause(ctx, param[0], "", nil)
 	return CmdResult{Msg: DefaultMsg}, nil
 }
 

--- a/pp/setting/print.go
+++ b/pp/setting/print.go
@@ -1,11 +1,13 @@
 package setting
 
 import (
-	"github.com/stratosnet/sds/utils"
+	"context"
+
+	"github.com/stratosnet/sds/pp"
 )
 
 // ShowProgress
-func ShowProgress(p float32) {
+func ShowProgressWithContext(ctx context.Context, p float32) {
 	f := int(p)
 	m := int(100 - p)
 	str := ""
@@ -15,5 +17,5 @@ func ShowProgress(p float32) {
 	for i := 0; i < m; i++ {
 		str += "-"
 	}
-	utils.Log(str)
+	pp.Log(ctx, str)
 }

--- a/pp/task/download_task.go
+++ b/pp/task/download_task.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -8,13 +9,15 @@ import (
 	"strings"
 	"sync"
 	"time"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/pp"
+	"github.com/stratosnet/sds/pp/api/rpc"
 	"github.com/stratosnet/sds/pp/client"
 	"github.com/stratosnet/sds/pp/file"
 	"github.com/stratosnet/sds/pp/setting"
-	"github.com/stratosnet/sds/pp/api/rpc"
 	"github.com/stratosnet/sds/utils"
 )
 
@@ -149,7 +152,7 @@ func GetDownloadTaskWithSliceReqId(fileHash, walletAddress, sliceReqId string) (
 		utils.DebugLog("Can't find who created slice request", sliceReqId)
 		return nil, false
 	}
-	
+
 	task, ok := DownloadTaskMap.Load(fileHash + walletAddress + sid.(string))
 	if !ok {
 		return nil, false
@@ -180,17 +183,17 @@ func CheckDownloadTask(fileHash, walletAddress, fileReqId string) bool {
 }
 
 // CleanDownloadTask
-func CleanDownloadTask(fileHash, sliceHash, walletAddress, fileReqId string) {
+func CleanDownloadTask(ctx context.Context, fileHash, sliceHash, walletAddress, fileReqId string) {
 	if dlTask, ok := DownloadTaskMap.Load(fileHash + walletAddress + fileReqId); ok {
 
 		downloadTask := dlTask.(*DownloadTask)
 		delete(downloadTask.SliceInfo, sliceHash)
-		utils.DebugLogf("PP reported, clean slice task")
+		pp.DebugLogf(ctx, "PP reported, clean slice task")
 
 		if len(downloadTask.SliceInfo) > 0 {
 			return
 		}
-		utils.DebugLog("PP reported, clean all slice task")
+		pp.DebugLog(ctx, "PP reported, clean all slice task")
 		DownloadTaskMap.Delete(fileHash + walletAddress + fileReqId)
 	}
 }
@@ -241,16 +244,16 @@ func GetDownloadSlice(target *protos.ReqDownloadSlice) *DownloadSliceData {
 }
 
 // SaveDownloadFile
-func SaveDownloadFile(target *protos.RspDownloadSlice, fInfo *protos.RspFileStorageInfo) bool {
+func SaveDownloadFile(ctx context.Context, target *protos.RspDownloadSlice, fInfo *protos.RspFileStorageInfo) bool {
 	if fInfo.IsVideoStream {
-		return file.SaveFileData(target.Data, int64(target.SliceInfo.SliceOffset.SliceOffsetStart), target.SliceInfo.SliceHash, target.SliceInfo.SliceHash, fInfo.FileHash, fInfo.SavePath, fInfo.ReqId)
+		return file.SaveFileData(ctx, target.Data, int64(target.SliceInfo.SliceOffset.SliceOffsetStart), target.SliceInfo.SliceHash, target.SliceInfo.SliceHash, fInfo.FileHash, fInfo.SavePath, fInfo.ReqId)
 	} else {
-		return file.SaveFileData(target.Data, int64(target.SliceInfo.SliceOffset.SliceOffsetStart), target.SliceInfo.SliceHash, fInfo.FileName, target.FileHash, fInfo.SavePath, fInfo.ReqId)
+		return file.SaveFileData(ctx, target.Data, int64(target.SliceInfo.SliceOffset.SliceOffsetStart), target.SliceInfo.SliceHash, fInfo.FileName, target.FileHash, fInfo.SavePath, fInfo.ReqId)
 	}
 }
 
 // checkAgain only used by local file downloading session
-func checkAgain(fileHash string) {
+func checkAgain(ctx context.Context, fileHash string) {
 	reCount--
 	if f, ok := DownloadFileMap.Load(fileHash + LOCAL_REQID); ok {
 		fInfo := f.(*protos.RspFileStorageInfo)
@@ -259,31 +262,31 @@ func checkAgain(fileHash string) {
 			fName = fileHash
 		}
 		filePath := file.GetDownloadTmpPath(fileHash, fName, fInfo.SavePath)
-		if CheckFileOver(fileHash, filePath) {
+		if CheckFileOver(ctx, fileHash, filePath) {
 			DownloadFileMap.Delete(fileHash + LOCAL_REQID)
 			DownloadSpeedOfProgress.Delete(fileHash + LOCAL_REQID)
 			utils.Log("————————————————————————————————————download finished————————————————————————————————————")
-			DoneDownload(fileHash, fName, fInfo.SavePath)
+			DoneDownload(ctx, fileHash, fName, fInfo.SavePath)
 		} else {
 			if reCount > 0 {
 				time.Sleep(time.Second * 2)
-				checkAgain(fileHash)
+				checkAgain(ctx, fileHash)
 			}
 		}
 	}
 }
 
 // DoneDownload only used by local file downloading session
-func DoneDownload(fileHash, fileName, savePath string) {
+func DoneDownload(ctx context.Context, fileHash, fileName, savePath string) {
 	filePath := file.GetDownloadTmpPath(fileHash, fileName, savePath)
 	newFilePath := filePath[:len(filePath)-4]
 	err := os.Rename(filePath, newFilePath)
 	if err != nil {
-		utils.ErrorLog("DoneDownload", err)
+		pp.ErrorLog(ctx, "DoneDownload", err)
 	}
 	err = os.Remove(file.GetDownloadCsvPath(fileHash, fileName, savePath))
 	if err != nil {
-		utils.ErrorLog("DoneDownload Remove", err)
+		pp.ErrorLog(ctx, "DoneDownload Remove", err)
 	}
 	lastPath := strings.Replace(newFilePath, fileHash+"/", "", -1)
 	lastPath = addSeqNum2FileName(lastPath, 0)
@@ -292,56 +295,56 @@ func DoneDownload(fileHash, fileName, savePath string) {
 	// }
 	err = os.Rename(newFilePath, lastPath)
 	if err != nil {
-		utils.ErrorLog("DoneDownload Rename", err)
+		pp.ErrorLog(ctx, "DoneDownload Rename", err)
 	}
 	rmPath := strings.Replace(newFilePath, "/"+fileName, "", -1)
 	err = os.Remove(rmPath)
 	if err != nil {
-		utils.ErrorLog("DoneDownload Remove", err)
+		pp.ErrorLog(ctx, "DoneDownload Remove", err)
 	}
 
 	if _, ok := setting.ImageMap.Load(fileHash); ok {
-		utils.DebugLog("enter imageMap》》》》》》")
+		pp.DebugLog(ctx, "enter imageMap》》》》》》")
 		exist := false
 		exist, err = file.PathExists(setting.IMAGEPATH)
 		if err != nil {
-			utils.ErrorLog("ImageMap no", err)
+			pp.ErrorLog(ctx, "ImageMap no", err)
 		}
 		if !exist {
 			if err = os.MkdirAll(setting.IMAGEPATH, os.ModePerm); err != nil {
-				utils.ErrorLog("ImageMap mk no", err)
+				pp.ErrorLog(ctx, "ImageMap mk no", err)
 			}
 		}
-		utils.DebugLog("enter imageMap creation")
+		pp.DebugLog(ctx, "enter imageMap creation")
 		if setting.IsWindows {
 			var f, imageFile *os.File
 			f, err = os.Open(lastPath)
 			if err != nil {
-				utils.ErrorLog("err5>>>", err)
+				pp.ErrorLog(ctx, "err5>>>", err)
 			}
 			var img []byte
 			img, err = ioutil.ReadAll(f)
 			if err != nil {
-				utils.ErrorLog("img err6>>>", err)
+				pp.ErrorLog(ctx, "img err6>>>", err)
 			}
 			imageFile, err = os.OpenFile(setting.IMAGEPATH+fileHash, os.O_CREATE|os.O_RDWR, 0777)
 			if err != nil {
-				utils.ErrorLog("img err7>>>", err)
+				pp.ErrorLog(ctx, "img err7>>>", err)
 			}
 			_, err = imageFile.Write(img)
 			if err != nil {
-				utils.ErrorLog("img err8>>>", err)
+				pp.ErrorLog(ctx, "img err8>>>", err)
 			}
 			f.Close()
 			imageFile.Close()
 			err = os.Remove(lastPath)
 			if err != nil {
-				utils.ErrorLog("err9 Remove", err)
+				pp.ErrorLog(ctx, "err9 Remove", err)
 			}
 		} else {
 			err = os.Rename(lastPath, setting.IMAGEPATH+fileHash)
 			if err != nil {
-				utils.ErrorLog("ImageMap Rename", err)
+				pp.ErrorLog(ctx, "ImageMap Rename", err)
 			}
 		}
 
@@ -351,8 +354,8 @@ func DoneDownload(fileHash, fileName, savePath string) {
 }
 
 // CheckFileOver check finished
-func CheckFileOver(fileHash, filePath string) bool {
-	utils.DebugLog("CheckFileOver")
+func CheckFileOver(ctx context.Context, fileHash, filePath string) bool {
+	pp.DebugLog(ctx, "CheckFileOver")
 
 	if s, ok := DownloadSpeedOfProgress.Load(fileHash + LOCAL_REQID); ok {
 		sp := s.(*DownloadSP)
@@ -363,7 +366,7 @@ func CheckFileOver(fileHash, filePath string) bool {
 
 		// TODO calculate fileHash to check if download is finished
 		if info.Size() == sp.RawSize {
-			utils.DebugLog("ok!")
+			pp.DebugLog(ctx, "ok!")
 			return true
 		}
 		return false
@@ -372,8 +375,8 @@ func CheckFileOver(fileHash, filePath string) bool {
 }
 
 // CheckDownloadOver check download finished
-func CheckDownloadOver(fileHash string) (bool, float32) {
-	utils.DebugLog("CheckDownloadOver")
+func CheckDownloadOver(ctx context.Context, fileHash string) (bool, float32) {
+	pp.DebugLog(ctx, "CheckDownloadOver")
 	if f, ok := DownloadFileMap.Load(fileHash + LOCAL_REQID); ok {
 		fInfo := f.(*protos.RspFileStorageInfo)
 		if s, ok := DownloadSpeedOfProgress.Load(fileHash + LOCAL_REQID); ok {
@@ -384,21 +387,21 @@ func CheckDownloadOver(fileHash string) (bool, float32) {
 					fName = fileHash
 				}
 				filePath := file.GetDownloadTmpPath(fileHash, fName, fInfo.SavePath)
-				if CheckFileOver(fileHash, filePath) {
-					DoneDownload(fileHash, fName, fInfo.SavePath)
+				if CheckFileOver(ctx, fileHash, filePath) {
+					DoneDownload(ctx, fileHash, fName, fInfo.SavePath)
 					CleanDownloadFileAndConnMap(fileHash, LOCAL_REQID)
 					return true, 1.0
 				}
 				reCount = 5
 				time.Sleep(time.Second * 2)
-				checkAgain(fileHash)
+				checkAgain(ctx, fileHash)
 				return true, 1
 			}
 			return false, float32(sp.DownloadedSize) / float32(sp.TotalSize)
 		}
 		return false, 0
 	}
-	utils.ErrorLog("download error, failed to find the task, request download again")
+	pp.ErrorLog(ctx, "download error, failed to find the task, request download again")
 	return false, 0
 
 }
@@ -408,26 +411,26 @@ func CheckRemoteDownloadOver(fileHash, fileReqId string) {
 	key := fileHash + fileReqId
 	size := file.GetRemoteFileInfo(key)
 	utils.DebugLog("size:", string(size))
-	file.SetRemoteFileResult(key, rpc.Result{Return:rpc.SUCCESS})
+	file.SetRemoteFileResult(key, rpc.Result{Return: rpc.SUCCESS})
 	CleanDownloadFileAndConnMap(fileHash, fileReqId)
 }
 
 // DownloadProgress
-func DownloadProgress(fileHash, fileReqId string, size uint64) {
+func DownloadProgress(ctx context.Context, fileHash, fileReqId string, size uint64) {
 	if s, ok := DownloadSpeedOfProgress.Load(fileHash + fileReqId); ok {
 		sp := s.(*DownloadSP)
 		sp.DownloadedSize += int64(size)
 		p := float32(sp.DownloadedSize) / float32(sp.TotalSize) * 100
-		utils.Logf("downloaded：%.2f %% \n", p)
+		pp.Logf(ctx, "downloaded：%.2f %% \n", p)
 		setting.DownloadProgressMap.Store(fileHash, p)
-		setting.ShowProgress(p)
+		setting.ShowProgressWithContext(ctx, p)
 
 		// all bytes downloaded
 		if sp.DownloadedSize >= sp.TotalSize {
 			if file.IsFileRpcRemote(fileHash + fileReqId) {
 				CheckRemoteDownloadOver(fileHash, fileReqId)
 			} else {
-				go CheckDownloadOver(fileHash)
+				go CheckDownloadOver(ctx, fileHash)
 			}
 		}
 	}

--- a/pp/types/peer_list.go
+++ b/pp/types/peer_list.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"context"
 	"encoding/csv"
 	"os"
 	"strconv"
@@ -9,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stratosnet/sds/msg/protos"
-	"github.com/stratosnet/sds/utils"
+	"github.com/stratosnet/sds/pp"
 	"github.com/stratosnet/sds/utils/types"
 )
 
@@ -24,11 +25,11 @@ type PeerInfo struct {
 	RestAddress    string
 	WalletAddress  string
 
-	DiscoveryTime      int64 // When was this peer discovered for the first time
-	LastConnectionTime int64 // When was the last time we connected with this peer
-	Latency            int64 // The latency in ms
+	DiscoveryTime      int64  // When was this peer discovered for the first time
+	LastConnectionTime int64  // When was the last time we connected with this peer
+	Latency            int64  // The latency in ms
 	ConnetionType      string // the network for pp server listen on, 'tcp' or 'tcp4' or 'tcp6'
-	NetId              int64 // The ID of the current connection with this node, if it exists.
+	NetId              int64  // The ID of the current connection with this node, if it exists.
 	Status             int
 }
 
@@ -52,7 +53,7 @@ func (peerList *PeerList) Init(localNetworkAddress, ppListPath string) {
 	peerList.ppMapByP2pAddress = &sync.Map{}
 }
 
-func (peerList *PeerList) loadPPListFromFile() error {
+func (peerList *PeerList) loadPPListFromFile(ctx context.Context) error {
 	// TODO: Update this after we switch to JSON
 	csvFile, err := os.OpenFile(peerList.ppListPath, os.O_CREATE|os.O_RDWR, 0777)
 	defer csvFile.Close()
@@ -69,28 +70,28 @@ func (peerList *PeerList) loadPPListFromFile() error {
 
 	for _, item := range record {
 		if len(item) < 5 {
-			utils.ErrorLogf("LoadPPListFromFile ppList record is incomplete. %v fields (%v expected)", len(item), 5)
+			pp.ErrorLogf(ctx, "LoadPPListFromFile ppList record is incomplete. %v fields (%v expected)", len(item), 5)
 			continue
 		}
 		networkID, err := types.IDFromString(item[0])
 		if err != nil {
-			utils.ErrorLog("LoadPPListFromFile invalid networkId ["+item[0]+"]", err)
+			pp.ErrorLog(ctx, "LoadPPListFromFile invalid networkId ["+item[0]+"]", err)
 			continue
 		}
 
 		discoveryTime, err := strconv.ParseInt(item[3], 10, 64)
 		if err != nil {
-			utils.ErrorLog("LoadPPListFromFile invalid discoveryTime ["+item[3]+"]", err)
+			pp.ErrorLog(ctx, "LoadPPListFromFile invalid discoveryTime ["+item[3]+"]", err)
 			continue
 		}
 
 		lastConnectionTime, err := strconv.ParseInt(item[4], 10, 64)
 		if err != nil {
-			utils.ErrorLog("LoadPPListFromFile invalid lastConnectionTime ["+item[4]+"]", err)
+			pp.ErrorLog(ctx, "LoadPPListFromFile invalid lastConnectionTime ["+item[4]+"]", err)
 			continue
 		}
 
-		pp := &PeerInfo{
+		ppNode := &PeerInfo{
 			NetworkAddress:     networkID.NetworkAddress,
 			P2pAddress:         networkID.P2pAddress,
 			RestAddress:        item[1],
@@ -100,13 +101,13 @@ func (peerList *PeerList) loadPPListFromFile() error {
 			Status:             PEER_NOT_CONNECTED,
 		}
 
-		peerList.ppMapByNetworkAddress.Store(pp.NetworkAddress, pp)
-		peerList.ppMapByP2pAddress.Store(pp.P2pAddress, pp)
+		peerList.ppMapByNetworkAddress.Store(ppNode.NetworkAddress, ppNode)
+		peerList.ppMapByP2pAddress.Store(ppNode.P2pAddress, ppNode)
 	}
 	return nil
 }
 
-func (peerList *PeerList) savePPListToFile() error {
+func (peerList *PeerList) savePPListToFile(ctx context.Context) error {
 	peerList.rwmutex.Lock()
 	defer peerList.rwmutex.Unlock()
 
@@ -124,24 +125,24 @@ func (peerList *PeerList) savePPListToFile() error {
 
 	linesWritten := 0
 	peerList.ppMapByNetworkAddress.Range(func(k, v interface{}) bool {
-		pp, ok := v.(*PeerInfo)
+		ppNode, ok := v.(*PeerInfo)
 		if !ok {
-			utils.ErrorLogf("Invalid PP with network address %v in local PP list)", k)
+			pp.ErrorLogf(ctx, "Invalid PP with network address %v in local PP list)", k)
 			return true
 		}
 
 		line := []string{
-			types.NetworkID{P2pAddress: pp.P2pAddress, NetworkAddress: pp.NetworkAddress}.String(),
-			pp.RestAddress,
-			pp.NetworkAddress,
-			strconv.FormatInt(pp.DiscoveryTime, 10),
-			strconv.FormatInt(pp.LastConnectionTime, 10),
-			strconv.FormatInt(pp.Latency, 10),
+			types.NetworkID{P2pAddress: ppNode.P2pAddress, NetworkAddress: ppNode.NetworkAddress}.String(),
+			ppNode.RestAddress,
+			ppNode.NetworkAddress,
+			strconv.FormatInt(ppNode.DiscoveryTime, 10),
+			strconv.FormatInt(ppNode.LastConnectionTime, 10),
+			strconv.FormatInt(ppNode.Latency, 10),
 		}
 
 		err = writer.Write(line)
 		if err != nil {
-			utils.ErrorLog("error when writing local ppList to csv:", err)
+			pp.ErrorLog(ctx, "error when writing local ppList to csv:", err)
 			return true
 		}
 
@@ -149,11 +150,11 @@ func (peerList *PeerList) savePPListToFile() error {
 		return true
 	})
 	writer.Flush()
-	utils.DebugLogf("Saved %v PPs in local ppList", linesWritten)
+	pp.DebugLogf(ctx, "Saved %v PPs in local ppList", linesWritten)
 	return nil
 }
 
-func (peerList *PeerList) GetPPList() (list []*PeerInfo, total, connected int64) {
+func (peerList *PeerList) GetPPList(ctx context.Context) (list []*PeerInfo, total, connected int64) {
 	empty := true
 	peerList.ppMapByNetworkAddress.Range(func(k, v interface{}) bool {
 		empty = false
@@ -161,9 +162,9 @@ func (peerList *PeerList) GetPPList() (list []*PeerInfo, total, connected int64)
 	})
 
 	if empty {
-		err := peerList.loadPPListFromFile()
+		err := peerList.loadPPListFromFile(ctx)
 		if err != nil {
-			utils.ErrorLog("Error when loading the PP list from file", err)
+			pp.ErrorLog(ctx, "Error when loading the PP list from file", err)
 		}
 	}
 
@@ -172,26 +173,26 @@ func (peerList *PeerList) GetPPList() (list []*PeerInfo, total, connected int64)
 	connectCnt := int64(0)
 
 	peerList.ppMapByNetworkAddress.Range(func(k, v interface{}) bool {
-		pp, ok := v.(*PeerInfo)
+		ppNode, ok := v.(*PeerInfo)
 		if !ok {
-			utils.ErrorLogf("Invalid PP with network address %v in local PP map)", k)
+			pp.ErrorLogf(ctx, "Invalid PP with network address %v in local PP map)", k)
 			return true
 		}
 
 		totalCnt += 1
-		if pp.Status == PEER_CONNECTED {
+		if ppNode.Status == PEER_CONNECTED {
 			connectCnt += 1
 		}
 
-		ppList = append(ppList, pp)
+		ppList = append(ppList, ppNode)
 		return true
 	})
 
-	utils.Logf("#pp_in_list:[%d], #pp_connected:[%d]", totalCnt, connectCnt)
+	pp.Logf(ctx, "#pp_in_list:[%d], #pp_connected:[%d]", totalCnt, connectCnt)
 	return ppList, totalCnt, connectCnt
 }
 
-func (peerList *PeerList) SavePPList(target *protos.RspGetPPList) error {
+func (peerList *PeerList) SavePPList(ctx context.Context, target *protos.RspGetPPList) error {
 	addedPeer := false
 	for _, info := range target.PpList {
 		if info.NetworkAddress == peerList.localNetworkAddress {
@@ -201,13 +202,13 @@ func (peerList *PeerList) SavePPList(target *protos.RspGetPPList) error {
 			continue
 		}
 
-		existingPP := peerList.GetPPByNetworkAddress(info.NetworkAddress)
+		existingPP := peerList.GetPPByNetworkAddress(ctx, info.NetworkAddress)
 		if existingPP == nil {
-			existingPP = peerList.GetPPByP2pAddress(info.P2PAddress)
+			existingPP = peerList.GetPPByP2pAddress(ctx, info.P2PAddress)
 		}
 
 		if existingPP == nil {
-			pp := &PeerInfo{
+			ppNode := &PeerInfo{
 				NetworkAddress:     info.NetworkAddress,
 				P2pAddress:         info.P2PAddress,
 				RestAddress:        info.RestAddress,
@@ -218,24 +219,24 @@ func (peerList *PeerList) SavePPList(target *protos.RspGetPPList) error {
 				NetId:              0,
 				Status:             PEER_NOT_CONNECTED,
 			}
-			utils.DebugLogf("adding %v to local ppList", pp)
+			pp.DebugLogf(ctx, "adding %v to local ppList", ppNode)
 			if info.P2PAddress != "" {
-				peerList.ppMapByP2pAddress.Store(info.P2PAddress, pp)
+				peerList.ppMapByP2pAddress.Store(info.P2PAddress, ppNode)
 			}
 			if info.NetworkAddress != "" {
-				peerList.ppMapByNetworkAddress.Store(info.NetworkAddress, pp)
+				peerList.ppMapByNetworkAddress.Store(info.NetworkAddress, ppNode)
 			}
 			addedPeer = true
 		}
 	}
 
 	if addedPeer {
-		return peerList.savePPListToFile()
+		return peerList.savePPListToFile(ctx)
 	}
 	return nil
 }
 
-func (peerList *PeerList) GetPPByNetworkAddress(networkAddress string) *PeerInfo {
+func (peerList *PeerList) GetPPByNetworkAddress(ctx context.Context, networkAddress string) *PeerInfo {
 	if networkAddress == "" {
 		return nil
 	}
@@ -244,16 +245,16 @@ func (peerList *PeerList) GetPPByNetworkAddress(networkAddress string) *PeerInfo
 		return nil
 	}
 
-	pp, ok := value.(*PeerInfo)
+	ppNode, ok := value.(*PeerInfo)
 	if !ok {
-		utils.ErrorLogf("Invalid PP with network address %v in local PP list)", networkAddress)
+		pp.ErrorLogf(ctx, "Invalid PP with network address %v in local PP list)", networkAddress)
 		peerList.ppMapByNetworkAddress.Delete(networkAddress)
 		return nil
 	}
-	return pp
+	return ppNode
 }
 
-func (peerList *PeerList) GetPPByP2pAddress(p2pAddress string) *PeerInfo {
+func (peerList *PeerList) GetPPByP2pAddress(ctx context.Context, p2pAddress string) *PeerInfo {
 	if p2pAddress == "" {
 		return nil
 	}
@@ -262,124 +263,124 @@ func (peerList *PeerList) GetPPByP2pAddress(p2pAddress string) *PeerInfo {
 		return nil
 	}
 
-	pp, ok := value.(*PeerInfo)
+	ppNode, ok := value.(*PeerInfo)
 	if !ok {
-		utils.ErrorLogf("Invalid PP with p2p address %v in local PP list)", p2pAddress)
+		pp.ErrorLogf(ctx, "Invalid PP with p2p address %v in local PP list)", p2pAddress)
 		peerList.ppMapByP2pAddress.Delete(p2pAddress)
 		return nil
 	}
-	return pp
+	return ppNode
 }
 
-func (peerList *PeerList) DeletePPByNetworkAddress(networkAddress string) {
+func (peerList *PeerList) DeletePPByNetworkAddress(ctx context.Context, networkAddress string) {
 	if networkAddress == "" {
 		return
 	}
-	pp := peerList.GetPPByNetworkAddress(networkAddress)
-	if pp == nil {
-		utils.DebugLogf("Cannot delete PP %v from local PP list: PP doesn't exist", networkAddress)
+	ppNode := peerList.GetPPByNetworkAddress(ctx, networkAddress)
+	if ppNode == nil {
+		pp.DebugLogf(ctx, "Cannot delete PP %v from local PP list: PP doesn't exist", networkAddress)
 		return
 	}
 
-	utils.DebugLogf("deleting %v from local ppList", pp)
+	pp.DebugLogf(ctx, "deleting %v from local ppList", ppNode)
 	peerList.ppMapByNetworkAddress.Delete(networkAddress)
-	peerList.ppMapByP2pAddress.Delete(pp.P2pAddress)
+	peerList.ppMapByP2pAddress.Delete(ppNode.P2pAddress)
 
-	err := peerList.savePPListToFile()
+	err := peerList.savePPListToFile(ctx)
 	if err != nil {
-		utils.ErrorLog("Error when saving PP list to file", err)
+		pp.ErrorLog(ctx, "Error when saving PP list to file", err)
 	}
 }
 
-func (peerList *PeerList) UpdatePP(pp *PeerInfo) {
-	existingPP := peerList.GetPPByNetworkAddress(pp.NetworkAddress)
+func (peerList *PeerList) UpdatePP(ctx context.Context, ppNode *PeerInfo) {
+	existingPP := peerList.GetPPByNetworkAddress(ctx, ppNode.NetworkAddress)
 	if existingPP == nil {
-		existingPP = peerList.GetPPByP2pAddress(pp.P2pAddress)
+		existingPP = peerList.GetPPByP2pAddress(ctx, ppNode.P2pAddress)
 	}
 
 	now := time.Now().Unix()
 	if existingPP == nil {
 		// Add new peer
-		if pp.DiscoveryTime == 0 {
-			pp.DiscoveryTime = now
+		if ppNode.DiscoveryTime == 0 {
+			ppNode.DiscoveryTime = now
 		}
-		if pp.Status == PEER_CONNECTED && pp.LastConnectionTime == 0 {
-			pp.LastConnectionTime = now
+		if ppNode.Status == PEER_CONNECTED && ppNode.LastConnectionTime == 0 {
+			ppNode.LastConnectionTime = now
 		}
 
-		if pp.P2pAddress != "" {
-			peerList.ppMapByP2pAddress.Store(pp.P2pAddress, pp)
+		if ppNode.P2pAddress != "" {
+			peerList.ppMapByP2pAddress.Store(ppNode.P2pAddress, ppNode)
 		}
-		if pp.NetworkAddress != "" {
-			peerList.ppMapByNetworkAddress.Store(pp.NetworkAddress, pp)
+		if ppNode.NetworkAddress != "" {
+			peerList.ppMapByNetworkAddress.Store(ppNode.NetworkAddress, ppNode)
 		}
 	} else {
 		// Update existing peer info
-		if pp.P2pAddress != "" && existingPP.P2pAddress == "" {
-			existingPP.P2pAddress = pp.P2pAddress
-			peerList.ppMapByP2pAddress.Store(pp.P2pAddress, existingPP)
+		if ppNode.P2pAddress != "" && existingPP.P2pAddress == "" {
+			existingPP.P2pAddress = ppNode.P2pAddress
+			peerList.ppMapByP2pAddress.Store(ppNode.P2pAddress, existingPP)
 		}
-		if pp.NetworkAddress != "" && existingPP.NetworkAddress == "" {
-			existingPP.NetworkAddress = pp.NetworkAddress
-			peerList.ppMapByNetworkAddress.Store(pp.NetworkAddress, existingPP)
-		}
-
-		if pp.RestAddress != "" {
-			existingPP.RestAddress = pp.RestAddress
-		}
-		if pp.WalletAddress != "" {
-			existingPP.WalletAddress = pp.WalletAddress
-		}
-		if pp.LastConnectionTime != 0 {
-			existingPP.LastConnectionTime = pp.LastConnectionTime
+		if ppNode.NetworkAddress != "" && existingPP.NetworkAddress == "" {
+			existingPP.NetworkAddress = ppNode.NetworkAddress
+			peerList.ppMapByNetworkAddress.Store(ppNode.NetworkAddress, existingPP)
 		}
 
-		existingPP.Status = pp.Status
-		if pp.Status != PEER_NOT_CONNECTED {
-			existingPP.NetId = pp.NetId
+		if ppNode.RestAddress != "" {
+			existingPP.RestAddress = ppNode.RestAddress
+		}
+		if ppNode.WalletAddress != "" {
+			existingPP.WalletAddress = ppNode.WalletAddress
+		}
+		if ppNode.LastConnectionTime != 0 {
+			existingPP.LastConnectionTime = ppNode.LastConnectionTime
+		}
+
+		existingPP.Status = ppNode.Status
+		if ppNode.Status != PEER_NOT_CONNECTED {
+			existingPP.NetId = ppNode.NetId
 		} else {
-			if pp.LastConnectionTime == 0 {
+			if ppNode.LastConnectionTime == 0 {
 				existingPP.LastConnectionTime = now
 			}
 		}
 	}
 
-	err := peerList.savePPListToFile()
+	err := peerList.savePPListToFile(ctx)
 	if err != nil {
-		utils.ErrorLog("Error when saving PP list to file", err)
+		pp.ErrorLog(ctx, "Error when saving PP list to file", err)
 	}
 }
 
-func (peerList *PeerList) PPDisconnected(p2pAddress, networkAddress string) {
-	pp := peerList.GetPPByP2pAddress(p2pAddress)
-	if pp == nil {
-		pp = peerList.GetPPByNetworkAddress(networkAddress)
+func (peerList *PeerList) PPDisconnected(ctx context.Context, p2pAddress, networkAddress string) {
+	ppNode := peerList.GetPPByP2pAddress(ctx, p2pAddress)
+	if ppNode == nil {
+		ppNode = peerList.GetPPByNetworkAddress(ctx, networkAddress)
 	}
 
-	if pp == nil {
-		utils.DebugLogf("PP %v (%v) is offline. It was not in the local PP list", p2pAddress, networkAddress)
+	if ppNode == nil {
+		pp.DebugLogf(ctx, "PP %v (%v) is offline. It was not in the local PP list", p2pAddress, networkAddress)
 	} else {
-		pp.Status = PEER_NOT_CONNECTED
-		pp.LastConnectionTime = time.Now().Unix()
-		utils.DebugLogf("PP %v is offline", pp)
+		ppNode.Status = PEER_NOT_CONNECTED
+		ppNode.LastConnectionTime = time.Now().Unix()
+		pp.DebugLogf(ctx, "PP %v is offline", ppNode)
 
-		err := peerList.savePPListToFile()
+		err := peerList.savePPListToFile(ctx)
 		if err != nil {
-			utils.ErrorLog("Error when saving PP list to file", err)
+			pp.ErrorLog(ctx, "Error when saving PP list to file", err)
 		}
 	}
 }
 
-func (peerList *PeerList) PPDisconnectedNetId(netId int64) {
+func (peerList *PeerList) PPDisconnectedNetId(ctx context.Context, netId int64) {
 	found := false
 	peerList.ppMapByNetworkAddress.Range(func(k, v interface{}) bool {
-		pp, ok := v.(*PeerInfo)
+		ppNode, ok := v.(*PeerInfo)
 		if !ok {
-			utils.ErrorLogf("Invalid PP with network address %v in local PP list)", k)
+			pp.ErrorLogf(ctx, "Invalid PP with network address %v in local PP list)", k)
 			return true
 		}
-		if pp.Status == PEER_CONNECTED && pp.NetId == netId {
-			peerList.PPDisconnected(pp.P2pAddress, pp.NetworkAddress)
+		if ppNode.Status == PEER_CONNECTED && ppNode.NetId == netId {
+			peerList.PPDisconnected(ctx, ppNode.P2pAddress, ppNode.NetworkAddress)
 			found = true
 			return false
 		}
@@ -387,6 +388,6 @@ func (peerList *PeerList) PPDisconnectedNetId(netId int64) {
 	})
 
 	if !found {
-		utils.DebugLogf("PP with netId %v is offline, but it was not found in the local PP list", netId)
+		pp.DebugLogf(ctx, "PP with netId %v is offline, but it was not found in the local PP list", netId)
 	}
 }

--- a/utils/database/sql/executor.go
+++ b/utils/database/sql/executor.go
@@ -3,12 +3,13 @@ package sql
 import (
 	"database/sql"
 	"errors"
-	"github.com/stratosnet/sds/utils"
-	"github.com/stratosnet/sds/utils/cache"
-	"github.com/stratosnet/sds/utils/database/rows"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/stratosnet/sds/utils"
+	"github.com/stratosnet/sds/utils/cache"
+	"github.com/stratosnet/sds/utils/database/rows"
 )
 
 // @version 0.0.1
@@ -16,7 +17,7 @@ import (
 // Executor Database Driver
 type Executor struct {
 	db    *sql.DB
-	Log   *utils.Logger
+	Log   *utils.CombinedLogger
 	cache cache.Cache
 	Debug bool
 }

--- a/utils/log.go
+++ b/utils/log.go
@@ -91,7 +91,7 @@ func NewTrafficLogger(filePath string, enableStd, enableFile bool) *CombinedLogg
 //Log calls default logger and output info log
 func DumpTraffic(v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	TrafficLogger.LogDepth(Info, 3, v...)
+	TrafficLogger.LogDepth(Info, 4, v...)
 }
 
 func GetLastLinesFromTrafficLog(path string, n uint64) []string {
@@ -187,7 +187,7 @@ func (l *Logger) Log(level LogLevel, v ...interface{}) {
 	if l.enabled {
 		l.logger.SetPrefix(l.GetLevelString(level))
 		//l.stdLogger.Println(v...)
-		l.logger.Output(2, fmt.Sprintln(v...))
+		l.logger.Output(3, fmt.Sprintln(v...))
 	}
 }
 
@@ -223,7 +223,7 @@ func (l *CombinedLogger) LogDepth(level LogLevel, calldepth int, v ...interface{
 
 func (l *CombinedLogger) ErrorLog(v ...interface{}) {
 	//l.Log(Error, v...)
-	l.LogDepth(Error, 3, v...)
+	l.LogDepth(Error, 4, v...)
 }
 
 func SetRpcLogger(rpc io.Writer) {
@@ -248,52 +248,52 @@ func ClearRpcLogger() {
 //Log calls default logger and output info log
 func Log(v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.LogDepth(Info, 3, v...)
+	MyLogger.LogDepth(Info, 4, v...)
 }
 
 func Logf(template string, v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.LogDepth(Info, 3, fmt.Sprintf(template, v...))
+	MyLogger.LogDepth(Info, 4, fmt.Sprintf(template, v...))
 }
 
 //ErrorLog call default logger and output error log
 func ErrorLog(v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.LogDepth(Error, 3, v...)
+	MyLogger.LogDepth(Error, 4, v...)
 }
 
 func WarnLog(v ...interface{}) {
-	MyLogger.LogDepth(Warn, 3, v...)
+	MyLogger.LogDepth(Warn, 4, v...)
 }
 
 //ErrorLogf call default logger and output error log
 func ErrorLogf(template string, v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.LogDepth(Error, 3, fmt.Errorf(template, v...))
+	MyLogger.LogDepth(Error, 4, fmt.Errorf(template, v...))
 }
 
 //DebugLog calls default logger and output debug log
 func DebugLog(v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.LogDepth(Debug, 3, v...)
+	MyLogger.LogDepth(Debug, 4, v...)
 }
 
 //DebugLog calls default logger and output debug log
 func DebugLogf(template string, v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.LogDepth(Debug, 3, fmt.Sprintf(template, v...))
+	MyLogger.LogDepth(Debug, 4, fmt.Sprintf(template, v...))
 }
 
 //DetailLog calls default logger and output detail log
 func DetailLog(v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.LogDepth(Detail, 3, v...)
+	MyLogger.LogDepth(Detail, 4, v...)
 }
 
 //DetailLog calls default logger and output detail log
 func DetailLogf(template string, v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.LogDepth(Detail, 3, fmt.Sprintf(template, v...))
+	MyLogger.LogDepth(Detail, 4, fmt.Sprintf(template, v...))
 }
 
 // CheckError  TODO This is a bad way to call error log, as you cannot know where this method is called in your error log

--- a/utils/log.go
+++ b/utils/log.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 )
 
 //log level
@@ -23,20 +24,24 @@ type LogLevel int
 
 var level2String = make(map[LogLevel]string)
 
+var RpcLoggerMap = NewAutoCleanMap(60 * time.Minute)
+
 type Logger struct {
-	stdLogger  *log.Logger
-	fileLogger *log.Logger
-	rpcLogger  *log.Logger
-	enablestd  bool
-	enablefile bool
-	enablerpc  bool
-	loglevel   LogLevel
+	logger   *log.Logger
+	enabled  bool
+	logLevel LogLevel
 }
 
-var MyLogger *Logger
-var TrafficLogger *Logger
+type CombinedLogger struct {
+	stdLogger  *Logger
+	fileLogger *Logger
+}
 
-func newLogger(logFilepath string, enableStd, enableFile bool) *Logger {
+var MyLogger *CombinedLogger
+var TrafficLogger *CombinedLogger
+var RpcLogger *Logger
+
+func newLogger(logFilepath string, enableStd, enableFile bool) *CombinedLogger {
 	if err := os.MkdirAll(filepath.Dir(logFilepath), os.ModePerm); err != nil {
 		panic(fmt.Sprintf("log file '%v' initialize failed: %v", logFilepath, err.Error()))
 	}
@@ -46,30 +51,39 @@ func newLogger(logFilepath string, enableStd, enableFile bool) *Logger {
 		panic(fmt.Sprintf("log file '%v' open failed: %v", logFilepath, err.Error()))
 	}
 
-	logger := &Logger{
-		stdLogger:  log.New(os.Stdout, "\r\n", log.Ldate|log.Ltime|log.Lshortfile),
-		fileLogger: log.New(outfile, "\r\n", log.Ldate|log.Ltime|log.Lshortfile),
-		enablefile: enableFile,
-		enablestd:  enableStd,
-		loglevel:   Debug,
+	stdLogger := &Logger{
+		logger:   log.New(os.Stdout, "\r\n", log.Ldate|log.Ltime|log.Lshortfile),
+		enabled:  enableStd,
+		logLevel: Debug,
 	}
 
-	logger.stdLogger.SetPrefix("[Info]")
+	fileLogger := &Logger{
+		logger:   log.New(outfile, "\r\n", log.Ldate|log.Ltime|log.Lshortfile),
+		enabled:  enableFile,
+		logLevel: Debug,
+	}
+
+	logger := &CombinedLogger{
+		stdLogger:  stdLogger,
+		fileLogger: fileLogger,
+	}
+
+	logger.stdLogger.logger.SetPrefix("[Info]")
 
 	return logger
 
 }
 
-func NewLogger(filepath string, enableStd, enableFile bool) *Logger {
+func NewLogger(filepath string, enableStd, enableFile bool) *CombinedLogger {
 	return newLogger(filepath, enableStd, enableFile)
 }
 
-func NewDefaultLogger(filepath string, enableStd, enableFile bool) *Logger {
+func NewDefaultLogger(filepath string, enableStd, enableFile bool) *CombinedLogger {
 	MyLogger = newLogger(filepath, enableStd, enableFile)
 	return MyLogger
 }
 
-func NewTrafficLogger(filePath string, enableStd, enableFile bool) *Logger {
+func NewTrafficLogger(filePath string, enableStd, enableFile bool) *CombinedLogger {
 	TrafficLogger = newLogger(filePath, enableStd, enableFile)
 	return TrafficLogger
 }
@@ -77,7 +91,7 @@ func NewTrafficLogger(filePath string, enableStd, enableFile bool) *Logger {
 //Log calls default logger and output info log
 func DumpTraffic(v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	TrafficLogger.logDepth(Info, 3, v...)
+	TrafficLogger.LogDepth(Info, 3, v...)
 }
 
 func GetLastLinesFromTrafficLog(path string, n uint64) []string {
@@ -134,138 +148,153 @@ func init() {
 
 //SetLogLevel
 func (l *Logger) SetLogLevel(lv LogLevel) {
-	l.loglevel = lv
+	l.logLevel = lv
 }
 
-//getLevelString
-func (l *Logger) getLevelString(lv LogLevel) string {
+//GetLevelString
+func (l *Logger) GetLevelString(lv LogLevel) string {
 	if str, ok := level2String[lv]; ok {
 		return str
 	} else {
 
 		return "[" + strconv.Itoa(int(lv)) + "]"
 	}
-
 }
 
-func (l *Logger) SetEnablestd(b bool) {
-	l.enablestd = b
+func (l *Logger) SetEnabled(b bool) {
+	l.enabled = b
 }
 
-func (l *Logger) SetEnablefile(b bool) {
-	l.enablefile = b
+//SetLogLevel
+func (l *CombinedLogger) SetLogLevel(lv LogLevel) {
+	l.stdLogger.SetLogLevel(lv)
+	l.fileLogger.SetLogLevel(lv)
 }
 
-func (l *Logger) SetRpcLogger(rpc io.Writer) {
-	l.rpcLogger = log.New(rpc, "\r\n", log.Ldate|log.Ltime|log.Lshortfile)
-	l.enablerpc = true
+func (l *CombinedLogger) SetEnablestd(b bool) {
+	l.stdLogger.SetEnabled(b)
 }
 
-func (l *Logger) ClearRpcLogger() {
-	l.rpcLogger = nil
-	l.enablerpc = false
+func (l *CombinedLogger) SetEnablefile(b bool) {
+	l.fileLogger.SetEnabled(b)
 }
 
 func (l *Logger) Log(level LogLevel, v ...interface{}) {
-	if level < l.loglevel {
+	if level < l.logLevel {
 		return
 	}
 
-	if l.enablestd {
-		l.stdLogger.SetPrefix(l.getLevelString(level))
+	if l.enabled {
+		l.logger.SetPrefix(l.GetLevelString(level))
 		//l.stdLogger.Println(v...)
-		l.stdLogger.Output(2, fmt.Sprintln(v...))
-	}
-	if l.enablefile {
-		l.fileLogger.SetPrefix(l.getLevelString(level))
-		//l.fileLogger.Println(v...)
-		l.fileLogger.Output(2, fmt.Sprintln(v...))
-	}
-
-	if l.enablerpc {
-		l.rpcLogger.SetPrefix(l.getLevelString(level))
-		l.rpcLogger.Output(2, fmt.Sprintln(v...))
+		l.logger.Output(2, fmt.Sprintln(v...))
 	}
 }
 
-func (l *Logger) logDepth(level LogLevel, calldepth int, v ...interface{}) {
-	if level < l.loglevel {
+func (l *Logger) LogDepth(level LogLevel, calldepth int, v ...interface{}) {
+	if level < l.logLevel {
 		return
 	}
 
-	if l.enablestd {
-		l.stdLogger.SetPrefix(l.getLevelString(level))
+	if l.enabled && l.logger != nil {
+		l.logger.SetPrefix(l.GetLevelString(level))
 		//l.stdLogger.Println(v...)
-		l.stdLogger.Output(calldepth, fmt.Sprintln(v...))
-	}
-	if l.enablefile {
-		l.fileLogger.SetPrefix(l.getLevelString(level))
-		l.fileLogger.Output(calldepth, fmt.Sprintln(v...))
-		//l.fileLogger.Println(v...)
-	}
-
-	if l.enablerpc {
-		l.rpcLogger.SetPrefix(l.getLevelString(level))
-		l.rpcLogger.Output(calldepth, fmt.Sprintln(v...))
+		l.logger.Output(calldepth, fmt.Sprintln(v...))
 	}
 }
 
-func (l *Logger) ErrorLog(v ...interface{}) {
+func (l *CombinedLogger) Log(level LogLevel, v ...interface{}) {
+	if l.stdLogger != nil {
+		l.stdLogger.Log(level, v...)
+	}
+	if l.fileLogger != nil {
+		l.fileLogger.Log(level, v...)
+	}
+}
+
+func (l *CombinedLogger) LogDepth(level LogLevel, calldepth int, v ...interface{}) {
+	if l.stdLogger != nil {
+		l.stdLogger.LogDepth(level, calldepth, v...)
+	}
+	if l.fileLogger != nil {
+		l.fileLogger.LogDepth(level, calldepth, v...)
+	}
+}
+
+func (l *CombinedLogger) ErrorLog(v ...interface{}) {
 	//l.Log(Error, v...)
-	l.logDepth(Error, 3, v...)
+	l.LogDepth(Error, 3, v...)
+}
+
+func SetRpcLogger(rpc io.Writer) {
+	logLevel := Debug
+	if MyLogger != nil && MyLogger.stdLogger != nil {
+		logLevel = MyLogger.stdLogger.logLevel
+	}
+
+	RpcLogger = &Logger{
+		logger:   log.New(rpc, "\r\n", log.Ldate|log.Ltime|log.Lshortfile),
+		enabled:  true,
+		logLevel: logLevel,
+	}
+}
+
+func ClearRpcLogger() {
+	RpcLogger.enabled = false
+	RpcLogger.logger = nil
+	RpcLoggerMap = NewAutoCleanMap(60 * time.Minute)
 }
 
 //Log calls default logger and output info log
 func Log(v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.logDepth(Info, 3, v...)
+	MyLogger.LogDepth(Info, 3, v...)
 }
 
 func Logf(template string, v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.logDepth(Info, 3, fmt.Sprintf(template, v...))
+	MyLogger.LogDepth(Info, 3, fmt.Sprintf(template, v...))
 }
 
 //ErrorLog call default logger and output error log
 func ErrorLog(v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.logDepth(Error, 3, v...)
+	MyLogger.LogDepth(Error, 3, v...)
 }
 
 func WarnLog(v ...interface{}) {
-	MyLogger.logDepth(Warn, 3, v...)
+	MyLogger.LogDepth(Warn, 3, v...)
 }
 
 //ErrorLogf call default logger and output error log
 func ErrorLogf(template string, v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.logDepth(Error, 3, fmt.Errorf(template, v...))
+	MyLogger.LogDepth(Error, 3, fmt.Errorf(template, v...))
 }
 
 //DebugLog calls default logger and output debug log
 func DebugLog(v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.logDepth(Debug, 3, v...)
+	MyLogger.LogDepth(Debug, 3, v...)
 }
 
 //DebugLog calls default logger and output debug log
 func DebugLogf(template string, v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.logDepth(Debug, 3, fmt.Sprintf(template, v...))
+	MyLogger.LogDepth(Debug, 3, fmt.Sprintf(template, v...))
 }
 
 //DetailLog calls default logger and output detail log
 func DetailLog(v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.logDepth(Detail, 3, v...)
+	MyLogger.LogDepth(Detail, 3, v...)
 }
 
 //DetailLog calls default logger and output detail log
 func DetailLogf(template string, v ...interface{}) {
 	//GetLogger().Log(Info, v...)
-	MyLogger.logDepth(Detail, 3, fmt.Sprintf(template, v...))
+	MyLogger.LogDepth(Detail, 3, fmt.Sprintf(template, v...))
 }
-
 
 // CheckError  TODO This is a bad way to call error log, as you cannot know where this method is called in your error log
 // This give log line like this : [ERROR]2021/04/13 22:39:11 log.go:150: Fatal error: address 127.0.0.1: missing port in address


### PR DESCRIPTION
- The change is to make the terminal only receive logs regarding the command it sends and make exec command receive logs until a key is entered
  - split Logger into std, file and rpc
  - use a rpc logger map with reqId as key, so that the when logs it can know that if the reqId needs to use rpc logger
  - for all terminal commands, create a reqId, store it in rpc logger map and then pass the reqid via context
  - add log.go to package pp to deal with logging with context
  - update the exec command to keep on and receive logs after send out requests and exit when user enter ']'
  - add verbose flag (--verbose or -v) to terminal exec to turn on log
  - use the concept of reqId and parentReqId to track the logs that originate from the same root request

A log change are to update the logging to use the new log function that takes the context. The main logic changes are in the following files 
- cmd/ppd/terminal.go
- framework/client/cf/conn.go
- framework/core/codec.go
- pp/log.go
- pp/serv/terminal_cmd.go
- utils/log.go