### PR TITLE
feat/QB-1310 SP cpu high rate

### DIFF
--- a/framework/core/conn.go
+++ b/framework/core/conn.go
@@ -590,11 +590,16 @@ func writeLoop(c WriteCloser, wg *sync.WaitGroup) {
 	OuterFor:
 		for {
 			select {
-			case packet = <-sendCh:
+			case packet, ok := <-sendCh:
+				// selected, not received: break from the loop
+				if !ok {
+					break OuterFor
+				}
+				// drain pending messages
 				if packet != nil {
 					if err := sc.writePacket(packet); err != nil {
 						utils.ErrorLog(err)
-						return
+						break OuterFor
 					}
 					packet = nil
 				}


### PR DESCRIPTION
The reason:
When sendCh has been set to "closed" in other goroutines, and there is no packet in this buffered channel, it enters the selected branch(line 593) with the value of ok false. 
Since the value of packet is nil, quickly the control went back to for loop and comes back to the select again. 
The change:
Check the value of ok and adding a break is sufficient to resolve this scenario.