### PR TITLE
fix/QB-1393 terminal log doesn't work after introduced the req_id changes on speed tracking

### DIFF
--- a/framework/core/codec.go
+++ b/framework/core/codec.go
@@ -16,6 +16,7 @@ const (
 	serverCtxKey      ctxkey = "server"
 	netIDCtxKey       ctxkey = "netid"
 	reqIDCtxKey       ctxkey = "reqId"
+	packetIDCtxKey    ctxkey = "packetId"
 	parentReqIDCtxKey ctxkey = "parentReqId"
 	recvStartKey      ctxkey = "recvStartTime"
 )
@@ -87,6 +88,15 @@ func InheritRpcLoggerFromParentReqId(ctx context.Context, reqId int64) {
 	}
 }
 
+func GetPacketIdFromContext(ctx context.Context) int64 {
+	if ctx == nil || ctx.Value(packetIDCtxKey) == nil {
+		return 0
+	}
+
+	packetId := ctx.Value(packetIDCtxKey).(int64)
+	return packetId
+}
+
 func GetReqIdFromContext(ctx context.Context) int64 {
 	if ctx == nil || ctx.Value(reqIDCtxKey) == nil {
 		return 0
@@ -125,6 +135,10 @@ func GetParentReqIdFromContext(ctx context.Context) int64 {
 
 func CreateContextWithReqId(ctx context.Context, reqId int64) context.Context {
 	return context.WithValue(ctx, reqIDCtxKey, reqId)
+}
+
+func CreateContextWithPacketId(ctx context.Context, packetId int64) context.Context {
+	return context.WithValue(ctx, packetIDCtxKey, packetId)
 }
 
 func CreateContextWithRecvStartTime(ctx context.Context, recvStartTime int64) context.Context {

--- a/framework/core/packet.go
+++ b/framework/core/packet.go
@@ -1,7 +1,7 @@
 package core
 
 type WritePacketCostTime struct {
-	ReqId    int64
+	PacketId int64
 	CostTime int64
 }
 

--- a/msg/msg.go
+++ b/msg/msg.go
@@ -7,7 +7,8 @@ type RelayMsgBuf struct {
 	// ConnID    int64
 	// NetAdress string
 	// WalletAddress string
-	MSGHead header.MessageHead
-	MSGData []byte
-	Alloc   *[]byte
+	PacketId int64
+	MSGHead  header.MessageHead
+	MSGData  []byte
+	Alloc    *[]byte
 }

--- a/pp/event/download_slice.go
+++ b/pp/event/download_slice.go
@@ -4,11 +4,12 @@ package event
 import (
 	"context"
 	"fmt"
-	"github.com/stratosnet/sds/utils/types"
 	"net/http"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/stratosnet/sds/utils/types"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stratosnet/sds/framework/client/cf"
@@ -146,13 +147,13 @@ func splitSendDownloadSliceData(ctx context.Context, rsp *protos.RspDownloadSlic
 }
 
 func prepareSendDownloadSliceData(ctx context.Context, rsp *protos.RspDownloadSlice, tkSliceUID string) (int64, context.Context) {
-	genReqId, newCtx := peers.CreateNewContextAlterReqId(ctx)
+	packetId, newCtx := peers.CreateNewContextPacketId(ctx)
 	tkSlice := TaskSlice{
 		TkSliceUID: tkSliceUID,
 		IsUpload:   false,
 	}
-	ReqIdMap.Store(genReqId, tkSlice)
-	utils.DebugLogf("ReqIdMap.Store <==(%v, %v)", genReqId, tkSlice)
+	PacketIdMap.Store(packetId, tkSlice)
+	utils.DebugLogf("PacketIdMap.Store <==(%v, %v)", packetId, tkSlice)
 	downSendCostTimeMap.mux.Lock()
 	var ctStat = CostTimeStat{}
 	if val, ok := downSendCostTimeMap.dataMap.Load(rsp.TaskId + rsp.SliceInfo.SliceHash); ok {
@@ -162,7 +163,7 @@ func prepareSendDownloadSliceData(ctx context.Context, rsp *protos.RspDownloadSl
 	downSendCostTimeMap.dataMap.Store(tkSliceUID, ctStat)
 	downSendCostTimeMap.mux.Unlock()
 	utils.DebugLogf("downSendPacketWgMap.Store <== K:%v, V:%v]", tkSliceUID, ctStat)
-	return genReqId, newCtx
+	return packetId, newCtx
 }
 
 // RspDownloadSlice storagePP-PP

--- a/pp/peers/pp.go
+++ b/pp/peers/pp.go
@@ -116,7 +116,7 @@ func ListenSendPacket(handler func(core.WritePacketCostTime)) {
 			utils.Log("Quit signal detected. Shutting down ListenSendPacket ...")
 			return
 		case entry, ok := <-core.CostTimeCh:
-			if ok && entry.CostTime > 0 && entry.ReqId > 0 {
+			if ok && entry.CostTime > 0 && entry.PacketId > 0 {
 				utils.DebugLogf("received report from WritePacket: %v", entry)
 				handler(entry)
 			}

--- a/pp/peers/sp_peers.go
+++ b/pp/peers/sp_peers.go
@@ -204,9 +204,10 @@ func ScheduleReloadPPStatus(ctx context.Context, future time.Duration) {
 	ppPeerClock.AddJobWithInterval(future, GetPPStatusInitPPList(ctx))
 }
 
-func CreateNewContextAlterReqId(ctx context.Context) (int64, context.Context) {
+// CreateNewContextPacketId used for downloading / uploading speed tracking
+func CreateNewContextPacketId(ctx context.Context) (int64, context.Context) {
 	retCtx := ctx
-	genReqId, _ := utils.NextSnowFlakeId()
-	utils.DebugLogf("ReqId in new context changed to: %v", strconv.FormatInt(genReqId, 10))
-	return genReqId, core.CreateContextWithReqId(retCtx, genReqId)
+	packetId, _ := utils.NextSnowFlakeId()
+	utils.DebugLogf("PacketId in new context: %v", strconv.FormatInt(packetId, 10))
+	return packetId, core.CreateContextWithPacketId(retCtx, packetId)
 }


### PR DESCRIPTION
- add PacketId to RelayMsgBuf
- use PacketId to store cost time instead of altering new reqId