### PR TITLE
fix/QB-1412 hashring online counter fix

### DIFF
--- a/utils/hashring/hashring.go
+++ b/utils/hashring/hashring.go
@@ -103,9 +103,9 @@ func (r *HashRing) AddNode(node *Node) {
 
 	if _, exists := r.Nodes.Load(node.ID); !exists {
 		r.NodeCount++
+		r.NodeStatus.Store(node.ID, false)
 	}
 	r.Nodes.Store(node.ID, node)
-	r.NodeStatus.Store(node.ID, false)
 
 	r.NRing.Insert(node)
 }


### PR DESCRIPTION
When (exist == true), r.NodeStatus should not be reset to false without updating the counter r.NodeOkCount.