### PR TITLE
fix: fix get share file in both terminal and rpc

### DIFF
--- a/pp/event/share.go
+++ b/pp/event/share.go
@@ -195,7 +195,6 @@ func RspDeleteShare(ctx context.Context, conn core.WriteCloser) {
 func GetShareFile(ctx context.Context, keyword, sharePassword, saveAs, walletAddr string, walletPubkey, walletSign []byte, w http.ResponseWriter) {
 	pp.DebugLog(ctx, "GetShareFile for file ", keyword)
 	if setting.CheckLogin() {
-		core.RegisterReqId(ctx, task.LOCAL_REQID)
 		peers.SendMessageDirectToSPOrViaPP(ctx, requests.ReqGetShareFileData(keyword, sharePassword, saveAs, walletAddr, walletPubkey, walletSign), header.ReqGetShareFile)
 		storeResponseWriter(ctx, w)
 	} else {

--- a/pp/serv/terminal_cmd.go
+++ b/pp/serv/terminal_cmd.go
@@ -410,6 +410,7 @@ func (api *terminalCmd) CancelShare(param []string) (CmdResult, error) {
 
 func (api *terminalCmd) GetShareFile(param []string) (CmdResult, error) {
 	ctx := pp.CreateReqIdAndRegisterRpcLogger(context.Background())
+	core.RegisterReqId(ctx, task.LOCAL_REQID)
 	if len(param) < 1 {
 		return CmdResult{Msg: ""}, errors.New("input share link and retrieval secret key(if any)")
 	}


### PR DESCRIPTION
The line that registers reqId needs to be moved to terminal_cmd.go otherwise the rpc getshared fails