### PR TITLE
Feat/QB-936 Automatic Gas Calculation

### DIFF
--- a/cmd/ppd/terminal.go
+++ b/cmd/ppd/terminal.go
@@ -30,37 +30,37 @@ func run(cmd *cobra.Command, args []string, isExec bool) {
 	defer c.Close()
 
 	helpStr := "\n" +
-		"help                                                   show all the commands\n" +
-		"wallets                                                acquire all wallet wallets' address\n" +
-		"newwallet                                              create new wallet, input password in prompt\n" +
-		"login <walletAddress> ->password                       unlock and log in wallet, input password in prompt\n" +
-		"registerpeer                                           register peer to index node\n" +
-		"rp                                                     register peer to index node\n" +
-		"activate <amount> <fee> <gas>                          send transaction to stchain to become an active PP node\n" +
-		"updateStake <stakeDelta> <fee> <gas> <isIncrStake>     send transaction to stchain to update active pp's stake\n" +
-		"deactivate <fee> <gas>                                 send transaction to stchain to stop being an active PP node\n" +
-		"startmining                                            start mining\n" +
-		"prepay <amount> <fee> <gas>                            prepay stos to get ozone\n" +
-		"put <filepath>                                         upload file, need to consume ozone\n" +
-		"putstream <filepath>                                   upload video file for streaming, need to consume ozone (alpha version, encode format config impossible)\n" +
-		"list <filename>                                        query uploaded file by self\n" +
-		"list <page id>                                         query all files owned by the wallet, paginated\n" +
-		"delete <filehash>                                      delete file\n" +
-		"get <sdm://account/filehash> <saveAs>                  download file, need to consume ozone\n" +
+		"help                                                           show all the commands\n" +
+		"wallets                                                        acquire all wallet wallets' address\n" +
+		"newwallet                                                      create new wallet, input password in prompt\n" +
+		"login <walletAddress> ->password                               unlock and log in wallet, input password in prompt\n" +
+		"registerpeer                                                   register peer to index node\n" +
+		"rp                                                             register peer to index node\n" +
+		"activate <amount> <fee> optional<gas>                          send transaction to stchain to become an active PP node\n" +
+		"updateStake <stakeDelta> <fee> optional<gas> <isIncrStake>     send transaction to stchain to update active pp's stake\n" +
+		"deactivate <fee> optional<gas>                                 send transaction to stchain to stop being an active PP node\n" +
+		"startmining                                                    start mining\n" +
+		"prepay <amount> <fee> optional<gas>                            prepay stos to get ozone\n" +
+		"put <filepath>                                                 upload file, need to consume ozone\n" +
+		"putstream <filepath>                                           upload video file for streaming, need to consume ozone (alpha version, encode format config impossible)\n" +
+		"list <filename>                                                query uploaded file by self\n" +
+		"list <page id>                                                 query all files owned by the wallet, paginated\n" +
+		"delete <filehash>                                              delete file\n" +
+		"get <sdm://account/filehash> <saveAs>                          download file, need to consume ozone\n" +
 		"    e.g: get sdm://st1jn9skjsnxv26mekd8eu8a8aquh34v0m4mwgahg/e2ba7fd2390aad9213f2c60854e2b7728c6217309fcc421de5aacc7d4019a4fe\n" +
-		"sharefile <filehash> <duration> <is_private>           share an uploaded file\n" +
-		"allshare                                               list all shared files\n" +
-		"getsharefile <sharelink> <password>                    download a shared file, need to consume ozone\n" +
-		"cancelshare <shareID>                                  cancel a shared file\n" +
-		"ver                                                    version\n" +
-		"monitor                                                show monitor\n" +
-		"stopmonitor                                            stop monitor\n" +
-		"monitortoken                                           show token for pp monitor service\n" +
-		"config  <key> <value>                                  set config key value\n" +
-		"getoz <walletAddress> ->password                       get current ozone balance\n" +
-		"status                                                 get current resource node status\n" +
-		"maintenance start <duration>                           put the node in maintenance mode for the requested duration (in seconds)\n" +
-		"maintenance stop                                       stop the current maintenance\n"
+		"sharefile <filehash> <duration> <is_private>                   share an uploaded file\n" +
+		"allshare                                                       list all shared files\n" +
+		"getsharefile <sharelink> <password>                            download a shared file, need to consume ozone\n" +
+		"cancelshare <shareID>                                          cancel a shared file\n" +
+		"ver                                                            version\n" +
+		"monitor                                                        show monitor\n" +
+		"stopmonitor                                                    stop monitor\n" +
+		"monitortoken                                                   show token for pp monitor service\n" +
+		"config  <key> <value>                                          set config key value\n" +
+		"getoz <walletAddress> ->password                               get current ozone balance\n" +
+		"status                                                         get current resource node status\n" +
+		"maintenance start <duration>                                   put the node in maintenance mode for the requested duration (in seconds)\n" +
+		"maintenance stop                                               stop the current maintenance\n"
 
 	help := func(line string, param []string) bool {
 		fmt.Println(helpStr)

--- a/cmd/relayd/setting/setting.go
+++ b/cmd/relayd/setting/setting.go
@@ -33,8 +33,8 @@ type stratoschain struct {
 }
 
 type transactionsConfig struct {
-	Fee string `yaml:"fee"`
-	Gas int64  `yaml:"gas"`
+	Fee           string  `toml:"fee"`
+	GasAdjustment float64 `toml:"gas_adjustment"`
 }
 
 type blockchainInfoConfig struct {

--- a/example/network/node1/configs/config.toml
+++ b/example/network/node1/configs/config.toml
@@ -19,23 +19,23 @@ is_limit_upload_speed = false
 limit_upload_speed = 100
 chain_id = 'testchain_1-1'
 stratos_chain_url = 'http://127.0.0.1:1317'
+gas_adjustment = 1.3
 rest_port = '9201'
 internal_port = '9301'
 rpc_port = '9401'
 metrics_port = '9601'
 traffic_log_interval = 10
 max_connection = 1000
+[version]
+app_ver = 8
+min_app_ver = 8
+show = 'v0.8.1'
 
 [monitor]
 tls = false
 cert = ''
 key = ''
 port = '9501'
-
-[version]
-app_ver = 8
-min_app_ver = 8
-show = 'v0.8.1'
 
 [[sp_list]]
 p2p_address = ""

--- a/example/network/node2/configs/config.toml
+++ b/example/network/node2/configs/config.toml
@@ -19,23 +19,23 @@ is_limit_upload_speed = false
 limit_upload_speed = 100
 chain_id = 'testchain_1-1'
 stratos_chain_url = 'http://127.0.0.1:1317'
+gas_adjustment = 1.3
 rest_port = '9202'
 internal_port = '9302'
 rpc_port = '9402'
 metrics_port = '9602'
 traffic_log_interval = 10
 max_connection = 1000
+[version]
+app_ver = 8
+min_app_ver = 8
+show = 'v0.8.1'
 
 [monitor]
 tls = false
 cert = ''
 key = ''
 port = '9502'
-
-[version]
-app_ver = 8
-min_app_ver = 8
-show = 'v0.8.1'
 
 [[sp_list]]
 p2p_address = ""

--- a/example/network/node3/configs/config.toml
+++ b/example/network/node3/configs/config.toml
@@ -19,23 +19,23 @@ is_limit_upload_speed = false
 limit_upload_speed = 100
 chain_id = 'testchain_1-1'
 stratos_chain_url = 'http://127.0.0.1:1317'
+gas_adjustment = 1.3
 rest_port = '9203'
 internal_port = '9303'
 rpc_port = '9403'
 metrics_port = '9603'
 traffic_log_interval = 10
 max_connection = 1000
+[version]
+app_ver = 8
+min_app_ver = 8
+show = 'v0.8.1'
 
 [monitor]
 tls = false
 cert = ''
 key = ''
 port = '9503'
-
-[version]
-app_ver = 8
-min_app_ver = 8
-show = 'v0.8.1'
 
 [[sp_list]]
 p2p_address = ""

--- a/example/network/node4/configs/config.toml
+++ b/example/network/node4/configs/config.toml
@@ -19,23 +19,23 @@ is_limit_upload_speed = false
 limit_upload_speed = 100
 chain_id = 'testchain_1-1'
 stratos_chain_url = 'http://127.0.0.1:1317'
+gas_adjustment = 1.3
 rest_port = '9204'
 internal_port = '9304'
 rpc_port = '9404'
 metrics_port = '9604'
 traffic_log_interval = 10
 max_connection = 1000
+[version]
+app_ver = 8
+min_app_ver = 8
+show = 'v0.8.1'
 
 [monitor]
 tls = false
 cert = ''
 key = ''
 port = '9504'
-
-[version]
-app_ver = 8
-min_app_ver = 8
-show = 'v0.8.1'
 
 [[sp_list]]
 p2p_address = ""

--- a/pp/event/deactivate.go
+++ b/pp/event/deactivate.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
@@ -16,8 +17,8 @@ import (
 )
 
 // Deactivate Request that an active PP node becomes inactive
-func Deactivate(ctx context.Context, fee utiltypes.Coin, gas int64) error {
-	deactivateReq, err := reqDeactivateData(fee, gas)
+func Deactivate(ctx context.Context, txFee utiltypes.TxFee) error {
+	deactivateReq, err := reqDeactivateData(txFee)
 	if err != nil {
 		pp.ErrorLog(ctx, "Couldn't build PP deactivate request: "+err.Error())
 		return err
@@ -27,7 +28,7 @@ func Deactivate(ctx context.Context, fee utiltypes.Coin, gas int64) error {
 	return nil
 }
 
-// RspDeactivate. Response to asking the SP node to deactivate this PP node
+// RspDeactivate Response to asking the SP node to deactivate this PP node
 func RspDeactivate(ctx context.Context, conn core.WriteCloser) {
 	var target protos.RspDeactivatePP
 	success := requests.UnmarshalData(ctx, &target)
@@ -47,7 +48,7 @@ func RspDeactivate(ctx context.Context, conn core.WriteCloser) {
 		return
 	}
 
-	err := stratoschain.BroadcastTxBytes(target.Tx)
+	err := stratoschain.BroadcastTxBytes(target.Tx, sdktx.BroadcastMode_BROADCAST_MODE_BLOCK)
 	if err != nil {
 		pp.ErrorLog(ctx, "The deactivation transaction couldn't be broadcast", err)
 	} else {

--- a/pp/event/update_stake.go
+++ b/pp/event/update_stake.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/msg/header"
 	"github.com/stratosnet/sds/msg/protos"
@@ -16,9 +17,9 @@ import (
 	utiltypes "github.com/stratosnet/sds/utils/types"
 )
 
-// Update stake of node
-func UpdateStake(ctx context.Context, stakeDelta utiltypes.Coin, fee utiltypes.Coin, gas int64, incrStake bool) error {
-	updateStakeReq, err := reqUpdateStakeData(stakeDelta, fee, gas, incrStake)
+// UpdateStake Update stake of node
+func UpdateStake(ctx context.Context, stakeDelta utiltypes.Coin, txFee utiltypes.TxFee, incrStake bool) error {
+	updateStakeReq, err := reqUpdateStakeData(stakeDelta, txFee, incrStake)
 	if err != nil {
 		pp.ErrorLog(ctx, "Couldn't build update PP stake request: "+err.Error())
 		return err
@@ -46,7 +47,7 @@ func RspUpdateStake(ctx context.Context, conn core.WriteCloser) {
 	}
 	setting.State = target.UpdateState
 
-	err := stratoschain.BroadcastTxBytes(target.Tx)
+	err := stratoschain.BroadcastTxBytes(target.Tx, sdktx.BroadcastMode_BROADCAST_MODE_BLOCK)
 	if err != nil {
 		pp.ErrorLog(ctx, "The UpdateStake transaction couldn't be broadcast", err)
 	} else {

--- a/pp/setting/setting.go
+++ b/pp/setting/setting.go
@@ -131,6 +131,7 @@ type config struct {
 	LimitUploadSpeed     uint64       `toml:"limit_upload_speed"`
 	ChainId              string       `toml:"chain_id"`
 	StratosChainUrl      string       `toml:"stratos_chain_url"`
+	GasAdjustment        float64      `toml:"gas_adjustment"`
 	RestPort             string       `toml:"rest_port"`
 	InternalPort         string       `toml:"internal_port"`
 	RpcPort              string       `toml:"rpc_port"`
@@ -318,6 +319,7 @@ func defaultConfig() *config {
 		LimitUploadSpeed:     0,
 		ChainId:              "tropos-4",
 		StratosChainUrl:      "http://127.0.0.1:1317",
+		GasAdjustment:        1.3,
 		RestPort:             "",
 		InternalPort:         "",
 		TrafficLogInterval:   10,


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-936

- added automatic gas calculation by calling the tx simulate endpoint on stchain
- relayd always use automatic gas calculation
- pp uses automatic gas calculation if the gas amount isn't specified
- added `gas_adjustment` entry in pp config
- added `blockchain_info.transactions.gas_adjustment` entry in relayd config
- removed the old `BuildTxBytes` method (unused) and minor refactor to transaction building and broadcasting 