### PR TITLE
fix/QB-1516 fix pp lost in online count in hashring

### DIFF
--- a/pp/p2pserver/reconnect.go
+++ b/pp/p2pserver/reconnect.go
@@ -60,7 +60,7 @@ func (p *P2pServer) ConfirmOptSP(ctx context.Context, spNetworkAddr string) {
 		return
 	}
 	p.setOptSP(spNetworkAddr)
-	p.mainSpConn.Close()
+	p.mainSpConn.ClientClose(true)
 }
 
 func (p *P2pServer) GetOptSPAndClear() (string, error) {


### PR DESCRIPTION
Close() in package client/conn is a graceful way to close the current conn and try to reconnect to the same peer. 
When a PP decides to connect to an alternative SP, an intentionally close should be done. ClientClose(true) should be called.