### PR TITLE
feat/QB-1611 relayd fee calculation

### DIFF
--- a/cmd/relayd/setting/setting.go
+++ b/cmd/relayd/setting/setting.go
@@ -47,13 +47,12 @@ type stratoschain struct {
 }
 
 type transactionsConfig struct {
-	Fee           string  `toml:"fee"`
+	GasPrice      string  `toml:"gas_price"`
 	GasAdjustment float64 `toml:"gas_adjustment"`
 }
 
 type blockchainInfoConfig struct {
 	ChainId      string             `toml:"chain_id"`
-	Token        string             `toml:"token"`
 	Transactions transactionsConfig `toml:"transactions"`
 }
 
@@ -94,11 +93,10 @@ func LoadConfig(path string) error {
 func defaultConfig() *config {
 	return &config{
 		BlockchainInfo: blockchainInfoConfig{
-			ChainId: "test-chain",
-			Token:   "wei",
+			ChainId: "testchain_1-1",
 			Transactions: transactionsConfig{
-				Fee:           "30000wei",
-				GasAdjustment: 1.3,
+				GasPrice:      "1000000000wei",
+				GasAdjustment: 2.0,
 			},
 		},
 		Keys: keysConfig{

--- a/example/relayd/node1/config/config.toml
+++ b/example/relayd/node1/config/config.toml
@@ -1,12 +1,13 @@
 [version]
-app_ver = 7
-min_app_ver = 7
+app_ver = 9
+min_app_ver = 9
+show = "v0.9.0"
 
 [sds]
 network_address = "127.0.0.1"
-api_port = "18081"
-client_port = "18888"
-websocket_port = "18889"
+api_port = "8081"
+client_port = "8888"
+websocket_port = "8889"
 [sds.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
@@ -22,12 +23,11 @@ channel_size = 2000
 max_msg_per_tx = 250
 
 [blockchain_info]
-chain_id = "testchain"
-
+chain_id = "testchain_1-1"
 [blockchain_info.transactions]
-fee = "1000000000000000wei"
-gas_adjustment = 1.3
+gas_price = "1000000000wei"
+gas_adjustment = 2.0
 
 [keys]
-wallet_path = "config/st1k9hfqps9s2tpnfxch2avvevyvtry0zth39gdzc.json"
+wallet_path = "config/st1a8ngk4tjvuxneyuvyuy9nvgehkpfa38hm8mp3x.json"
 wallet_password = "aaa"

--- a/example/relayd/node2/config/config.toml
+++ b/example/relayd/node2/config/config.toml
@@ -1,12 +1,13 @@
 [version]
-app_ver = 7
-min_app_ver = 7
+app_ver = 9
+min_app_ver = 9
+show = "v0.9.0"
 
 [sds]
 network_address = "127.0.0.1"
-api_port = "28081"
-client_port = "28888"
-websocket_port = "28889"
+api_port = "18081"
+client_port = "18888"
+websocket_port = "18889"
 [sds.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
@@ -22,12 +23,11 @@ channel_size = 2000
 max_msg_per_tx = 250
 
 [blockchain_info]
-chain_id = "testchain"
-
+chain_id = "testchain_1-1"
 [blockchain_info.transactions]
-fee = "1000000000000000wei"
-gas_adjustment = 1.3
+gas_price = "1000000000wei"
+gas_adjustment = 2.0
 
 [keys]
-wallet_path = "config/st1rwnmgk0x2n2wry876dkxq2hhcce8k7kzspppax.json"
+wallet_path = "config/st1k9hfqps9s2tpnfxch2avvevyvtry0zth39gdzc.json"
 wallet_password = "aaa"

--- a/example/relayd/node3/config/config.toml
+++ b/example/relayd/node3/config/config.toml
@@ -1,12 +1,13 @@
 [version]
-app_ver = 7
-min_app_ver = 7
+app_ver = 9
+min_app_ver = 9
+show = "v0.9.0"
 
 [sds]
 network_address = "127.0.0.1"
-api_port = "38081"
-client_port = "38888"
-websocket_port = "38889"
+api_port = "28081"
+client_port = "28888"
+websocket_port = "28889"
 [sds.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
@@ -22,12 +23,11 @@ channel_size = 2000
 max_msg_per_tx = 250
 
 [blockchain_info]
-chain_id = "testchain"
-
+chain_id = "testchain_1-1"
 [blockchain_info.transactions]
-fee = "1000000000000000wei"
-gas_adjustment = 1.3
+gas_price = "1000000000wei"
+gas_adjustment = 2.0
 
 [keys]
-wallet_path = "config/st1ewlfmhl8j0p2jesfd2xrqp0qjeh2222gs9uefh.json"
+wallet_path = "config/st1rwnmgk0x2n2wry876dkxq2hhcce8k7kzspppax.json"
 wallet_password = "aaa"

--- a/example/relayd/node4/config/config.toml
+++ b/example/relayd/node4/config/config.toml
@@ -1,12 +1,13 @@
 [version]
-app_ver = 7
-min_app_ver = 7
+app_ver = 9
+min_app_ver = 9
+show = "v0.9.0"
 
 [sds]
 network_address = "127.0.0.1"
-api_port = "8081"
-client_port = "8888"
-websocket_port = "8889"
+api_port = "38081"
+client_port = "38888"
+websocket_port = "38889"
 [sds.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
@@ -22,12 +23,11 @@ channel_size = 2000
 max_msg_per_tx = 250
 
 [blockchain_info]
-chain_id = "testchain"
-
+chain_id = "testchain_1-1"
 [blockchain_info.transactions]
-fee = "1000000000000000wei"
-gas_adjustment = 1.3
+gas_price = "1000000000wei"
+gas_adjustment = 2.0
 
 [keys]
-wallet_path = "config/st1a8ngk4tjvuxneyuvyuy9nvgehkpfa38hm8mp3x.json"
+wallet_path = "config/st1ewlfmhl8j0p2jesfd2xrqp0qjeh2222gs9uefh.json"
 wallet_password = "aaa"


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-1611

- relayd now uses `gas price * gas amount` to calculate fee amount
- removed `blockchain_info.transactions.fee` and `blockchain_info.token` config
- added `blockchain_info.transactions.gas_price` config
- updated localnet relayd configs