### PR TITLE
feat/QB-1656 logs in sds rpc client

### DIFF
--- a/pp/api/rpc/types.go
+++ b/pp/api/rpc/types.go
@@ -120,8 +120,9 @@ type Result struct {
 	ReqId       string  `json:"reqid,omitempty"`
 	OffsetStart *uint64 `json:"offsetstart,omitempty"`
 	OffsetEnd   *uint64 `json:"offsetend,omitempty"`
-	FileData    string  `json:"filedata,omitempty"`
 	FileHash    string  `json:"filehash,omitempty"`
+	FileName    string  `json:"filename,omitempty"`
+	FileData    string  `json:"filedata,omitempty"`
 }
 
 type FileListResult struct {

--- a/pp/file/file.go
+++ b/pp/file/file.go
@@ -161,7 +161,7 @@ func SaveFileData(ctx context.Context, data []byte, offset int64, sliceHash, fil
 
 	if IsFileRpcRemote(fileHash + fileReqId) {
 		// write to rpc
-		return SaveRemoteFileData(fileHash+fileReqId, data, uint64(offset))
+		return SaveRemoteFileData(fileHash+fileReqId, fileName, data, uint64(offset))
 	}
 	wmutex.Lock()
 	defer wmutex.Unlock()

--- a/pp/file/file_rpc.go
+++ b/pp/file/file_rpc.go
@@ -135,7 +135,7 @@ func SendFileDataBack(hash string, content []byte) {
 }
 
 // SaveRemoteFileData application calls this func to send a slice of file data to remote user during download process
-func SaveRemoteFileData(key string, data []byte, offset uint64) bool {
+func SaveRemoteFileData(key, fileName string, data []byte, offset uint64) bool {
 	if data == nil {
 		return false
 	}
@@ -155,6 +155,7 @@ func SaveRemoteFileData(key string, data []byte, offset uint64) bool {
 		OffsetStart: &offset,
 		OffsetEnd:   &offsetend,
 		FileData:    b64.StdEncoding.EncodeToString(data),
+		FileName:    fileName,
 	}
 
 	SetRemoteFileResult(key, result)

--- a/pp/serv/rpc.go
+++ b/pp/serv/rpc.go
@@ -289,7 +289,11 @@ func (api *rpcApi) DownloadData(ctx context.Context, param rpc_api.ParamDownload
 		if result == nil || !(result.Return == rpc_api.DOWNLOAD_OK || result.Return == rpc_api.DL_OK_ASK_INFO) {
 			file.CleanFileHash(key)
 		}
+		if result != nil {
+			result.FileName = ""
+		}
 	}
+
 	return *result
 }
 


### PR DESCRIPTION
* file name is included in the first download response, and rpc_client creates the file ./download/<file name> for writing data. 
* check if the folder ./download/ exist, otherwise create it
* corrected ozone balance: a decimal number in unit of ozone
* display the share Id and share link when share a file 