### PR TITLE
Fix/Prepay cmd bug fix

### DIFF
--- a/pp/serv/terminal_cmd.go
+++ b/pp/serv/terminal_cmd.go
@@ -281,6 +281,7 @@ func (api *terminalCmd) Prepay(ctx context.Context, param []string) (CmdResult, 
 			if errGas != nil {
 				return CmdResult{Msg: ""}, errors.New("invalid third param. Should be a valid bech32 wallet address (beneficiary address) OR a positive integer (gas)")
 			}
+			beneficiaryAddr, _ = utiltypes.WalletAddressFromBech(setting.WalletAddress)
 			txFee.Gas = gas
 			txFee.Simulate = false
 		}


### PR DESCRIPTION
Bug fix: When prepay cmd use parameters "amount" + "fee" + "gas", optinal parameter "beneficiary" can't get the sender wallet address as default