### PR TITLE
fix/qb1738: fix incorrect path joining when using putstream cmd of rpcclient

### DIFF
--- a/pp/file/file_rpc.go
+++ b/pp/file/file_rpc.go
@@ -3,6 +3,7 @@ package file
 import (
 	"context"
 	b64 "encoding/base64"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -142,9 +143,10 @@ func CacheRemoteFileData(fileHash string, offset *protos.SliceOffset, fileName s
 	// send event and open the pipe for coming data
 	SetRemoteFileResult(fileHash, *r)
 
+	_, fileName = path.Split(fileName)
 	fileMg, err := OpenTmpFile(fileHash, fileName)
 	if err != nil {
-		return errors.Wrap(err, "failed opening tem file")
+		return errors.Wrap(err, "failed opening temp file")
 	}
 	defer func() {
 		_ = fileMg.Close()

--- a/pp/file/file_rpc.go
+++ b/pp/file/file_rpc.go
@@ -3,7 +3,6 @@ package file
 import (
 	"context"
 	b64 "encoding/base64"
-	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -143,7 +142,6 @@ func CacheRemoteFileData(fileHash string, offset *protos.SliceOffset, fileName s
 	// send event and open the pipe for coming data
 	SetRemoteFileResult(fileHash, *r)
 
-	_, fileName = path.Split(fileName)
 	fileMg, err := OpenTmpFile(fileHash, fileName)
 	if err != nil {
 		return errors.Wrap(err, "failed opening temp file")

--- a/pp/requests/requests.go
+++ b/pp/requests/requests.go
@@ -120,7 +120,7 @@ func ReqGetWalletOzData(walletAddr, reqId string) *protos.ReqGetWalletOz {
 }
 
 // RequestUploadFile a file from an owner instead from a "path" belongs to PP's default wallet
-func RequestUploadFile(fileName, fileHash string, fileSize uint64, walletAddress, walletPubkey, signature string, isEncrypted, isVideoStream bool) *protos.ReqUploadFile {
+func RequestUploadFile(fileName, fileHash string, fileSize uint64, walletAddress, walletPubkey, signature string, isEncrypted, isVideoStream bool) (*protos.ReqUploadFile, error) {
 	utils.Log("fileName: ", fileName)
 	encryptionTag := ""
 	if isEncrypted {
@@ -136,13 +136,13 @@ func RequestUploadFile(fileName, fileHash string, fileSize uint64, walletAddress
 	wpk, err := types.WalletPubkeyFromBech(walletPubkey)
 	if err != nil {
 		utils.ErrorLog("wrong wallet pubkey")
-		return nil
+		return nil, errors.New("wrong wallet pubkey")
 	}
 	// decode the hex encoded signature back to []byte which is used in protobuf messages
 	wsig, err := hex.DecodeString(signature)
 	if err != nil {
 		utils.ErrorLog("wrong signature")
-		return nil
+		return nil, errors.New("wrong signature")
 	}
 	req := &protos.ReqUploadFile{
 		FileInfo: &protos.FileInfo{
@@ -165,7 +165,7 @@ func RequestUploadFile(fileName, fileHash string, fileSize uint64, walletAddress
 		duration, err := file.GetVideoDuration(filepath.Join(setting.GetRootPath(), file.TEMP_FOLDER, fileHash, fileName))
 		if err != nil {
 			utils.Log("Failed to get the length of the video: ", err)
-			return nil
+			return nil, errors.Wrap(err, "Failed to get the length of the video")
 		}
 		req.FileInfo.Duration = duration
 	}
@@ -176,7 +176,7 @@ func RequestUploadFile(fileName, fileHash string, fileSize uint64, walletAddress
 		HasUpload: 0,
 	}
 	task.UploadProgressMap.Store(fileHash, p)
-	return req
+	return req, nil
 }
 
 // RequestUploadFileData assume the PP's current wallet is the owner, otherwise RequestUploadFile() should be used instead

--- a/pp/serv/rpc.go
+++ b/pp/serv/rpc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"encoding/hex"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -227,6 +228,12 @@ func (api *rpcPubApi) RequestUploadStream(ctx context.Context, param rpc_api.Par
 	pubkey := param.WalletPubkey
 	signature := param.Signature
 	size := fileSize
+
+	_, name := filepath.Split(fileName)
+	if len(name) > 0 {
+		utils.DebugLogf("fileName is trimmed from %v to %v", fileName, name)
+		fileName = name
+	}
 
 	// verify if wallet and public key match
 	if utiltypes.VerifyWalletAddr(pubkey, walletAddr) != 0 {

--- a/pp/serv/rpc.go
+++ b/pp/serv/rpc.go
@@ -127,7 +127,10 @@ func (api *rpcPubApi) RequestUpload(ctx context.Context, param rpc_api.ParamReqU
 	}
 
 	// start to upload file
-	p := requests.RequestUploadFile(fileName, fileHash, uint64(size), walletAddr, pubkey, signature, false, false)
+	p, err := requests.RequestUploadFile(fileName, fileHash, uint64(size), walletAddr, pubkey, signature, false, false)
+	if err != nil {
+		return rpc_api.Result{Return: rpc_api.FILE_REQ_FAILURE}
+	}
 	metrics.UploadPerformanceLogNow(param.FileHash + ":SND_REQ_UPLOAD_SP")
 	p2pserver.GetP2pServer(ctx).SendMessageToSPServer(ctx, p, header.ReqUploadFile)
 
@@ -708,7 +711,11 @@ func uploadStreamTmpFile(ctx context.Context, fileHash, fileName string, fileSiz
 		utils.ErrorLog("failed uploading stream tmp file", err.Error())
 		return
 	}
-	p := requests.RequestUploadFile(fileName, fileHash, fileSize, walletAddr, pubkey, signature, false, true)
+	p, err := requests.RequestUploadFile(fileName, fileHash, fileSize, walletAddr, pubkey, signature, false, true)
+	if err != nil {
+		utils.ErrorLog("failed creating RequestUploadFile", err.Error())
+		return
+	}
 	p2pserver.GetP2pServer(ctx).SendMessageToSPServer(ctx, p, header.ReqUploadFile)
 }
 


### PR DESCRIPTION
- qb1738: fix incorrect path joining when using putstream cmd of rpcclient