### PR TITLE
QB-1793 Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine AS build-env
+FROM golang:1.19-alpine AS build-env
 
 # Set up dependencies
 ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
@@ -38,4 +38,4 @@ COPY --from=build-env /go/bin/relayd /usr/bin/relayd
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
-CMD ["ppd"]
+CMD ["ppd start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM golang:1.18-alpine AS build-env
+
+# Set up dependencies
+ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
+
+# Install minimum necessary dependencies
+RUN apk add --no-cache $PACKAGES
+
+# Set working directory for the build
+WORKDIR /go/src/github.com/stratosnet/sds
+
+# Add source files
+COPY . .
+RUN make update install
+
+
+# Final image
+FROM alpine:edge
+
+ENV WORK_DIR /sds
+ENV RUN_AS_USER sds
+
+# Install ca-certificates
+RUN apk add --update ca-certificates
+
+ARG uid=2048
+ARG gid=2048
+
+RUN addgroup --gid $gid "$RUN_AS_USER" && \
+    adduser -S -G "$RUN_AS_USER" --uid $uid "$RUN_AS_USER" -h "$WORK_DIR"
+
+WORKDIR $WORK_DIR
+
+# Copy over binaries from the build-env
+COPY --from=build-env /go/bin/ppd /usr/bin/ppd
+COPY --from=build-env /go/bin/relayd /usr/bin/relayd
+
+COPY entrypoint.sh /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+CMD ["ppd"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BUILDDIR ?= $(CURDIR)/target
-TEST_DOCKER_REPO=sds-e2e
+TEST_DOCKER_REPO=sds-rsnode
 
 BUILD_TARGETS := build install
 
@@ -20,8 +20,8 @@ build-mac: go.sum
 build-windows: go.sum
 	GOOS=windows GOARCH=amd64 $(MAKE) build
 
-build-docker-e2e:
-	@docker build -f tests/e2e/Dockerfile -t ${TEST_DOCKER_REPO}:$(shell git rev-parse --short HEAD) --build-arg uid=$(shell id -u) --build-arg gid=$(shell id -g) .
+build-docker:
+	@docker build -f Dockerfile -t ${TEST_DOCKER_REPO}:$(shell git rev-parse --short HEAD) --build-arg uid=$(shell id -u) --build-arg gid=$(shell id -g) .
 	@docker tag ${TEST_DOCKER_REPO}:$(shell git rev-parse --short HEAD) ${TEST_DOCKER_REPO}:$(shell git rev-parse --abbrev-ref HEAD | sed 's#/#_#g')
 	@docker tag ${TEST_DOCKER_REPO}:$(shell git rev-parse --short HEAD) ${TEST_DOCKER_REPO}:latest
 
@@ -37,4 +37,4 @@ coverage:
 lint:
 	golangci-lint run
 
-.PHONY: build-linux build-mac build clean coverage lint
+.PHONY: build-linux build-mac build-docker build clean coverage lint

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+RUN_AS_USER=${RUN_AS_USER:-$(whoami)}
+WORK_DIR=${WORK_DIR:-.}
+PPD_BIN=${PPD_BIN:-/usr/bin/ppd}
+CHAIN_ID=${CHAIN_ID:-tropos-5}
+STCHAIN_URL=${STCHAIN_URL:-https://rest-tropos.thestratos.org:443}
+SP_LIST=${SP_LIST:-"18.130.202.53:8888 35.74.33.155:8888 52.13.28.64:8888 3.9.152.251:8888 35.73.160.68:8888 18.223.175.117:8888 46.51.251.196:8888"}
+
+
+if [ ! -d "$WORK_DIR/configs" ]
+then
+  echo "[entrypoint] Init SDS resource node..."
+  printf "\n\n$node\n\n\n\n\nYes" | $PPD_BIN config --create-p2p-key --create-wallet --home $WORK_DIR
+
+  echo "[entrypoint] Set stratos_chain_url as '$STCHAIN_URL'"
+  sed -i "s!stratos_chain_url = '.*'!stratos_chain_url = '$STCHAIN_URL'!g" $WORK_DIR/configs/config.toml
+
+  echo "[entrypoint] Set chain_id as '$CHAIN_ID'"
+  sed -i "s!chain_id = '.*'!chain_id = '$CHAIN_ID'!g" $WORK_DIR/configs/config.toml
+
+  echo "[entrypoint] Set the default SDS meta node as '$SP_LIST'"
+  sed -i "/\[\[sp_list\]\]/,/^network_address = '.*'$/ s/.*//" $WORK_DIR/configs/config.toml
+  for sp in $SP_LIST
+  do
+    cat << EOF >> $WORK_DIR/configs/config.toml
+[[sp_list]]
+p2p_address = ''
+p2p_public_key = ''
+network_address = '$sp'
+EOF
+  done
+
+  echo "[entrypoint] Set the default ports"
+  sed -i "s/rest_port = '.*'/rest_port= '9608'/g" $WORK_DIR/configs/config.toml
+  sed -i "s/internal_port = '.*'/internal_port = '9708'/g" $WORK_DIR/configs/config.toml
+  sed -i "s/rpc_port = '.*'/rpc_port = '8135'/g" $WORK_DIR/configs/config.toml
+  sed -i "s/metrics_port = '.*'/metrics_port = '8765'/g" $WORK_DIR/configs/config.toml
+  sed -i "s/metrics_port = '.*'/metrics_port = '8765'/g" $WORK_DIR/configs/config.toml
+  sed -i "/\[monitor\]/,/^port = '.*'$/ s/^port = '.*'$/port = '5433'/" $WORK_DIR/configs/config.toml
+fi
+
+chown -R $RUN_AS_USER $WORK_DIR
+su -s /bin/sh - $RUN_AS_USER -c "$@"


### PR DESCRIPTION
## Change details
* Use `entrypoint.sh` to update permissions when we mount the folder to the container.
* Update Makefile to easily build docker images.

## How to use
### Quickly start a SDS resource node
```
docker build -t sds-rsnode .
docker run -d --name sds-rsnode -p 18081:18081 sds-rsnode
```
You need to confirm that port `18081` is **accessible from the internet**. It is used to communicate with other nodes.

If you want to keeps all configuration and data files outside the container, you can mount a local dir to the container:
```
docker run -d --name sds-rsnode -p 18081:18081 -v ~/sds-rsnode:/sds sds-rsnode
```
The configuration and data files will save to `~/sds-rsnode`.

### Start SDS terminal
You may want to interact with SDS resource node via ternimal:
```
docker exec -it sds-rsnode ppd terminal
```
Then you can follow the [README.md](https://github.com/stratosnet/sds/blob/main/README.md) to [Acquiring STOS Tokens](https://github.com/stratosnet/sds/blob/main/README.md#acquiring-stos-tokens) and [Registering to a Meta Node](https://github.com/stratosnet/sds/blob/main/README.md#registering-to-a-meta-node), etc.