### PR TITLE
fix/QB 1828 adjust uploading timeout

### DIFF
--- a/pp/event/upload_slice.go
+++ b/pp/event/upload_slice.go
@@ -80,7 +80,7 @@ func ReqUploadFileSlice(ctx context.Context, conn core.WriteCloser) {
 	}
 
 	// spam check after verified the sp's response
-	if time.Now().Unix()-target.RspUploadFile.TimeStamp > setting.SPAM_THRESHOLD_SP_SIGN_LATENCY {
+	if time.Now().Unix()-target.RspUploadFile.TimeStamp > target.RspUploadFile.TotalSlice*setting.SPAM_THRESHOLD_SP_SIGN_LATENCY {
 		rsp := &protos.RspUploadFileSlice{
 			Result: &protos.Result{
 				State: protos.ResultState_RES_FAIL,

--- a/pp/setting/setting.go
+++ b/pp/setting/setting.go
@@ -47,7 +47,7 @@ const (
 	DEFAULT_MAX_CONNECTION = 1000
 
 	DEFAULT_MIN_UNSUSPEND_STAKE    = "1stos" // 1 stos
-	SPAM_THRESHOLD_SP_SIGN_LATENCY = 60      //in second
+	SPAM_THRESHOLD_SP_SIGN_LATENCY = 120     // in second
 
 	SOFT_RAM_LIMIT_TIER_0    = int64(3 * units.GiB)
 	SOFT_RAM_LIMIT_TIER_1    = int64(7 * units.GiB)


### PR DESCRIPTION
According to the test, rpc_client takes about 20 seconds for a slice, and the js client takes almost 60 seconds for a slice. 
The threshold per slice is adjusted to 120 seconds. 