### PR TITLE
fix/qb1980: fix timeout issue upon signature verification failure while…

### DIFF
--- a/pp/event/share.go
+++ b/pp/event/share.go
@@ -237,7 +237,7 @@ func RspGetShareFile(ctx context.Context, _ core.WriteCloser) {
 			rpcResult.SequenceNumber = target.SequenceNumber
 			file.SetFileShareResult(target.ShareRequest.Signature.Address+reqId, rpcResult)
 			go func(fileInfo *protos.FileInfo) {
-				if walletSign := file.GetSignatureFromRemote(fileInfo.FileHash + walletAddr); walletSign != nil {
+				if walletSign := file.GetSignatureFromRemote(fileInfo.FileHash + walletAddr + reqId); walletSign != nil {
 					req = requests.RequestDownloadFile(ctx, fileInfo.FileHash, filePath, walletAddr, reqId, walletSign,
 						walletPubkey, target.ShareRequest, target.ShareRequest.ReqTime)
 					p2pserver.GetP2pServer(ctx).SendMessageDirectToSPOrViaPP(ctx, req, header.ReqFileStorageInfo)

--- a/pp/namespace/api.go
+++ b/pp/namespace/api.go
@@ -877,7 +877,7 @@ func (api *rpcPubApi) RequestDownloadShared(ctx context.Context, param rpc_api.P
 		return rpc_api.Result{Return: rpc_api.WRONG_FILE_INFO}
 	}
 
-	file.SetSignature(param.FileHash+param.Signature.Address, wsig)
+	file.SetSignature(param.FileHash+param.Signature.Address+param.ReqId, wsig)
 
 	// start from here, the control flow follows that of download file
 	key := fileHash + param.ReqId


### PR DESCRIPTION
- qb1980: fix timeout issue upon signature verification failure while DownloadShared from rpc call
- qb1980: append reqId to the key of signature chan to increase compatibility of parallel download with rpc calls