### PR TITLE
fix/qb2016: change improperly used filePath to fileName in rpc apis 

### DIFF
--- a/cmd/ppd/ipfs/rootcmd.go
+++ b/cmd/ppd/ipfs/rootcmd.go
@@ -250,13 +250,13 @@ func reqOzone() (*rpc_api.ParamReqGetOzone, error) {
 	}, nil
 }
 
-func reqUploadMsg(fileName, hash, sn string) (*rpc_api.ParamReqUploadFile, error) {
+func reqUploadMsg(filePath, hash, sn string) (*rpc_api.ParamReqUploadFile, error) {
 	// file size
-	info, err := file.GetFileInfo(fileName)
+	info, err := file.GetFileInfo(filePath)
 	if info == nil || err != nil {
 		return nil, errors.New("failed to get file information")
 	}
-
+	fileName := info.Name()
 	// wallet address
 	ret := readWalletKeys(WalletAddress)
 	if !ret {

--- a/example/rpcclient/rpc_client.go
+++ b/example/rpcclient/rpc_client.go
@@ -29,6 +29,7 @@ func reqUploadMsg(filePath, hash, sn string) []byte {
 		utils.ErrorLog("Failed to get file information.", err.Error())
 		return nil
 	}
+	fileName := info.Name()
 	nowSec := time.Now().Unix()
 	// signature
 	sign, err := WalletPrivateKey.Sign([]byte(utils.GetFileUploadWalletSignMessage(hash, WalletAddress, sn, nowSec)))
@@ -42,7 +43,7 @@ func reqUploadMsg(filePath, hash, sn string) []byte {
 	// param
 	var params = []rpc.ParamReqUploadFile{}
 	params = append(params, rpc.ParamReqUploadFile{
-		FileName: filePath,
+		FileName: fileName,
 		FileSize: int(info.Size()),
 		FileHash: hash,
 		Signature: rpc.Signature{


### PR DESCRIPTION
- qb2016: change improperly used filePath to fileName in rpc apis  