### PR TITLE
fix/qb2018: fix fileHash mismatch issue during put/putstream a file thru rpc apis

### DIFF
--- a/example/rpcclient/rpc_client.go
+++ b/example/rpcclient/rpc_client.go
@@ -159,13 +159,14 @@ func put(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func reqUploadStreamMsg(fileName, hash, sn string) []byte {
+func reqUploadStreamMsg(filePath, hash, sn string) []byte {
 	// file size
-	info, err := file.GetFileInfo(fileName)
+	info, err := file.GetFileInfo(filePath)
 	if err != nil {
 		utils.ErrorLog("Failed to get file information.", err.Error())
 		return nil
 	}
+	fileName := info.Name()
 	nowSec := time.Now().Unix()
 	// signature
 	sign, err := WalletPrivateKey.Sign([]byte(utils.GetFileUploadWalletSignMessage(hash, WalletAddress, sn, nowSec)))

--- a/pp/file/file_rpc.go
+++ b/pp/file/file_rpc.go
@@ -163,7 +163,7 @@ func CacheRemoteFileData(fileHash string, offset *protos.SliceOffset, folderName
 
 	var read int64 = 0
 	var writeOffset int64 = 0
-	if !writeFromStartOffset {
+	if writeFromStartOffset {
 		writeOffset = int64(offset.SliceOffsetStart)
 	}
 


### PR DESCRIPTION
- qb2018: fix fileHash mismatch issue for tmp file during put/putstream a file using rpc apis
- qb2018: change misused filePath to fileName while uploading file thru rpc apis