### PR TITLE
feat/QB-1990 relayd automatically refresh connections

### DIFF
--- a/cmd/relayd/setting/setting.go
+++ b/cmd/relayd/setting/setting.go
@@ -22,8 +22,9 @@ type AppVersion struct {
 }
 
 type connectionRetries struct {
-	Max           int `toml:"max"`
-	SleepDuration int `toml:"sleep_duration"`
+	Max             int `toml:"max"`
+	SleepDuration   int `toml:"sleep_duration"`   // Milliseconds
+	RefreshInterval int `toml:"refresh_interval"` // Seconds
 }
 
 type grpcConfig struct {
@@ -33,7 +34,6 @@ type grpcConfig struct {
 
 type sds struct {
 	ApiPort           string            `toml:"api_port"`
-	ClientPort        string            `toml:"client_port"`
 	NetworkAddress    string            `toml:"network_address"`
 	WebsocketPort     string            `toml:"websocket_port"`
 	ConnectionRetries connectionRetries `toml:"connection_retries"`
@@ -110,12 +110,12 @@ func defaultConfig() *config {
 		},
 		SDS: sds{
 			ApiPort:        "8081",
-			ClientPort:     "8088",
 			NetworkAddress: "127.0.0.1",
 			WebsocketPort:  "8889",
 			ConnectionRetries: connectionRetries{
-				Max:           100,
-				SleepDuration: 3000,
+				Max:             100,
+				SleepDuration:   3000,
+				RefreshInterval: 24 * 60 * 60,
 			},
 		},
 		StratosChain: stratoschain{
@@ -125,8 +125,9 @@ func defaultConfig() *config {
 			},
 			WebsocketServer: "127.0.0.1:26657",
 			ConnectionRetries: connectionRetries{
-				Max:           100,
-				SleepDuration: 3000,
+				Max:             100,
+				SleepDuration:   3000,
+				RefreshInterval: 24 * 60 * 60,
 			},
 			Broadcast: broadcast{
 				ChannelSize: 2000,

--- a/example/network/node1/config/config.toml
+++ b/example/network/node1/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9401'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node10/config/config.toml
+++ b/example/network/node10/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9410'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node11/config/config.toml
+++ b/example/network/node11/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9411'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node12/config/config.toml
+++ b/example/network/node12/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9412'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node13/config/config.toml
+++ b/example/network/node13/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9413'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node14/config/config.toml
+++ b/example/network/node14/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9414'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node15/config/config.toml
+++ b/example/network/node15/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9415'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node16/config/config.toml
+++ b/example/network/node16/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9416'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node2/config/config.toml
+++ b/example/network/node2/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9402'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node3/config/config.toml
+++ b/example/network/node3/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9403'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node4/config/config.toml
+++ b/example/network/node4/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9404'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node5/config/config.toml
+++ b/example/network/node5/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9405'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node6/config/config.toml
+++ b/example/network/node6/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9406'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node7/config/config.toml
+++ b/example/network/node7/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9407'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node8/config/config.toml
+++ b/example/network/node8/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9408'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/network/node9/config/config.toml
+++ b/example/network/node9/config/config.toml
@@ -74,6 +74,8 @@ cert_file_path = ''
 # Path to the TLS private key file
 key_file_path = ''
 port = '9409'
+# List of IPs that are allowed to connect to the monitor websocket port
+allowed_origins = ['localhost']
 
 # Configuration for video streaming
 [streaming]

--- a/example/relayd/node1/config/config.toml
+++ b/example/relayd/node1/config/config.toml
@@ -1,7 +1,7 @@
 [version]
-app_ver = 9
-min_app_ver = 9
-show = "v0.9.0"
+app_ver = 10
+min_app_ver = 10
+show = "v0.10.0"
 
 [sds]
 network_address = "127.0.0.1"
@@ -11,6 +11,7 @@ websocket_port = "8889"
 [sds.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
+refresh_interval = 86400 # seconds
 
 [stratos_chain]
 websocket_server = "127.0.0.1:26657"
@@ -20,6 +21,7 @@ insecure = true
 [stratos_chain.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
+refresh_interval = 86400 # seconds
 [stratos_chain.broadcast]
 channel_size = 2000
 max_msg_per_tx = 250

--- a/example/relayd/node2/config/config.toml
+++ b/example/relayd/node2/config/config.toml
@@ -1,7 +1,7 @@
 [version]
-app_ver = 9
-min_app_ver = 9
-show = "v0.9.0"
+app_ver = 10
+min_app_ver = 10
+show = "v0.10.0"
 
 [sds]
 network_address = "127.0.0.1"
@@ -11,6 +11,7 @@ websocket_port = "18889"
 [sds.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
+refresh_interval = 86400 # seconds
 
 [stratos_chain]
 websocket_server = "127.0.0.1:26657"
@@ -20,6 +21,7 @@ insecure = true
 [stratos_chain.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
+refresh_interval = 86400 # seconds
 [stratos_chain.broadcast]
 channel_size = 2000
 max_msg_per_tx = 250

--- a/example/relayd/node3/config/config.toml
+++ b/example/relayd/node3/config/config.toml
@@ -1,7 +1,7 @@
 [version]
-app_ver = 9
-min_app_ver = 9
-show = "v0.9.0"
+app_ver = 10
+min_app_ver = 10
+show = "v0.10.0"
 
 [sds]
 network_address = "127.0.0.1"
@@ -11,6 +11,7 @@ websocket_port = "28889"
 [sds.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
+refresh_interval = 86400 # seconds
 
 [stratos_chain]
 websocket_server = "127.0.0.1:26657"
@@ -20,6 +21,7 @@ insecure = true
 [stratos_chain.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
+refresh_interval = 86400 # seconds
 [stratos_chain.broadcast]
 channel_size = 2000
 max_msg_per_tx = 250

--- a/example/relayd/node4/config/config.toml
+++ b/example/relayd/node4/config/config.toml
@@ -1,7 +1,7 @@
 [version]
-app_ver = 9
-min_app_ver = 9
-show = "v0.9.0"
+app_ver = 10
+min_app_ver = 10
+show = "v0.10.0"
 
 [sds]
 network_address = "127.0.0.1"
@@ -11,6 +11,7 @@ websocket_port = "38889"
 [sds.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
+refresh_interval = 86400 # seconds
 
 [stratos_chain]
 websocket_server = "127.0.0.1:26657"
@@ -20,6 +21,7 @@ insecure = true
 [stratos_chain.connection_retries]
 max = 100
 sleep_duration = 3000 # milliseconds
+refresh_interval = 86400 # seconds
 [stratos_chain.broadcast]
 channel_size = 2000
 max_msg_per_tx = 250

--- a/pp/serv/serv.go
+++ b/pp/serv/serv.go
@@ -163,7 +163,7 @@ func (bs *BaseServer) startMonitor() error {
 	}
 
 	var config = namespace.WsConfig{
-		Origins: []string{},
+		Origins: setting.Config.Monitor.AllowedOrigins,
 		Modules: []string{},
 		Prefix:  "",
 	}

--- a/pp/setting/setting.go
+++ b/pp/setting/setting.go
@@ -76,10 +76,11 @@ type NodeConfig struct {
 }
 
 type MonitorConfig struct {
-	TLS          bool   `toml:"tls" comment:"Should the monitor server use TLS? Eg: false"`
-	CertFilePath string `toml:"cert_file_path" comment:"Path to the TLS certificate file"`
-	KeyFilePath  string `toml:"key_file_path" comment:"Path to the TLS private key file"`
-	Port         string `toml:"port"`
+	TLS            bool     `toml:"tls" comment:"Should the monitor server use TLS? Eg: false"`
+	CertFilePath   string   `toml:"cert_file_path" comment:"Path to the TLS certificate file"`
+	KeyFilePath    string   `toml:"key_file_path" comment:"Path to the TLS private key file"`
+	Port           string   `toml:"port"`
+	AllowedOrigins []string `toml:"allowed_origins" comment:"List of IPs that are allowed to connect to the monitor websocket port"`
 }
 
 type TrafficConfig struct {
@@ -247,10 +248,11 @@ func defaultConfig() *config {
 			},
 		},
 		Monitor: MonitorConfig{
-			TLS:          false,
-			CertFilePath: "",
-			KeyFilePath:  "",
-			Port:         "18381",
+			TLS:            false,
+			CertFilePath:   "",
+			KeyFilePath:    "",
+			Port:           "18381",
+			AllowedOrigins: []string{"127.0.0.1"},
 		},
 		Streaming: StreamingConfig{
 			InternalPort: "18481",

--- a/relay/client/client.go
+++ b/relay/client/client.go
@@ -7,25 +7,23 @@ import (
 	"sync"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
-	"github.com/gorilla/websocket"
 	"github.com/stratosnet/sds/cmd/relayd/setting"
 	"github.com/stratosnet/sds/relay/stratoschain/grpc"
-	relaytypes "github.com/stratosnet/sds/relay/types"
 	"github.com/stratosnet/sds/utils"
 	"github.com/stratosnet/sds/utils/crypto/secp256k1"
 	"github.com/stratosnet/sds/utils/types"
 )
 
 type MultiClient struct {
-	cancel            context.CancelFunc
-	Ctx               context.Context
-	once              *sync.Once
-	sdsWebsocketConn  *websocket.Conn
-	txBroadcasterChan chan relaytypes.UnsignedMsg
-	sdsConn           connection
-	stchainConn       connection
-	WalletAddress     string
-	WalletPrivateKey  cryptotypes.PrivKey
+	cancel context.CancelFunc
+	Ctx    context.Context
+	once   *sync.Once
+
+	sdsConn     connection
+	stchainConn connection
+
+	WalletAddress    string
+	WalletPrivateKey cryptotypes.PrivKey
 }
 
 // connection is a generic interface for a client connection to an external service (sds or stchain)

--- a/relay/client/client.go
+++ b/relay/client/client.go
@@ -2,34 +2,14 @@ package client
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
-	"github.com/gorilla/websocket"
-	"github.com/pkg/errors"
-	"google.golang.org/protobuf/proto"
-
-	tmHttp "github.com/tendermint/tendermint/rpc/client/http"
-	coretypes "github.com/tendermint/tendermint/rpc/core/types"
-
-	"github.com/cosmos/cosmos-sdk/client"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
-	sdktypes "github.com/cosmos/cosmos-sdk/types"
-	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
-	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
-	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
-
+	"github.com/gorilla/websocket"
 	"github.com/stratosnet/sds/cmd/relayd/setting"
-	"github.com/stratosnet/sds/msg/protos"
-	"github.com/stratosnet/sds/relay"
-	"github.com/stratosnet/sds/relay/sds"
-	"github.com/stratosnet/sds/relay/stratoschain"
 	"github.com/stratosnet/sds/relay/stratoschain/grpc"
-	"github.com/stratosnet/sds/relay/stratoschain/handlers"
 	relaytypes "github.com/stratosnet/sds/relay/types"
 	"github.com/stratosnet/sds/utils"
 	"github.com/stratosnet/sds/utils/crypto/secp256k1"
@@ -37,33 +17,34 @@ import (
 )
 
 type MultiClient struct {
-	cancel                context.CancelFunc
-	Ctx                   context.Context
-	once                  *sync.Once
-	sdsWebsocketConn      *websocket.Conn
-	stratosWebsocketUrl   string
-	stratosEventsChannels *sync.Map
-	txBroadcasterChan     chan relaytypes.UnsignedMsg
-	WalletAddress         string
-	WalletPrivateKey      cryptotypes.PrivKey
-	wg                    *sync.WaitGroup
+	cancel            context.CancelFunc
+	Ctx               context.Context
+	once              *sync.Once
+	sdsWebsocketConn  *websocket.Conn
+	txBroadcasterChan chan relaytypes.UnsignedMsg
+	sdsConn           connection
+	stchainConn       connection
+	WalletAddress     string
+	WalletPrivateKey  cryptotypes.PrivKey
 }
 
-type websocketSubscription struct {
-	channel <-chan coretypes.ResultEvent
-	client  *tmHttp.HTTP
-	query   string
+// connection is a generic interface for a client connection to an external service (sds or stchain)
+type connection interface {
+	stop()
+	refresh() // Stop the connection if it was already started, then re-establish the connection
 }
 
 func NewClient(spHomePath string) (*MultiClient, error) {
 	ctx, cancel := context.WithCancel(context.Background())
+
 	newClient := &MultiClient{
-		cancel:                cancel,
-		Ctx:                   ctx,
-		once:                  &sync.Once{},
-		stratosEventsChannels: &sync.Map{},
-		wg:                    &sync.WaitGroup{},
+		cancel: cancel,
+		Ctx:    ctx,
+		once:   &sync.Once{},
 	}
+
+	newClient.sdsConn = newSdsConnection(newClient)
+	newClient.stchainConn = newStchainConnection(newClient)
 
 	err := newClient.loadKeys(spHomePath)
 	return newClient, err
@@ -94,11 +75,10 @@ func (m *MultiClient) Start() error {
 	// GRPC client to send msgs to stratos-chain
 	grpc.URL = setting.Config.StratosChain.GrpcServer.Url
 	grpc.INSECURE = setting.Config.StratosChain.GrpcServer.Insecure
-	// Client to subscribe to stratos-chain events and receive messages via websocket
-	m.stratosWebsocketUrl = setting.Config.StratosChain.WebsocketServer
 
-	go m.connectToSDS()
-	go m.connectToStratosChain()
+	// Start client connections
+	go m.sdsConn.refresh()
+	go m.stchainConn.refresh()
 
 	return nil
 }
@@ -106,383 +86,7 @@ func (m *MultiClient) Start() error {
 func (m *MultiClient) Stop() {
 	m.once.Do(func() {
 		m.cancel()
-		if m.sdsWebsocketConn != nil {
-			_ = m.sdsWebsocketConn.Close()
-		}
-
-		m.stratosEventsChannels.Range(func(k, v interface{}) bool {
-			subscription, ok := v.(websocketSubscription)
-			if !ok {
-				return false
-			}
-
-			go func() {
-				err := subscription.client.Unsubscribe(context.Background(), "", subscription.query)
-				if err != nil {
-					utils.ErrorLog("couldn't unsubscribe from "+subscription.query, err)
-				} else {
-					utils.Log("unsubscribed from " + subscription.query)
-				}
-				_ = subscription.client.Stop()
-			}()
-			return false
-		})
-
-		m.wg.Wait()
-		utils.Log("All client connections have been stopped")
+		m.sdsConn.stop()
+		m.stchainConn.stop()
 	})
-}
-
-func (m *MultiClient) connectToSDS() {
-	m.wg.Add(1)
-	defer m.wg.Done()
-	defer func() {
-		if r := recover(); r != nil {
-			utils.ErrorLog("Recovering from panic in SDS connection goroutine", r)
-		}
-	}()
-
-	sdsWebsocketUrl := setting.Config.SDS.NetworkAddress + ":" + setting.Config.SDS.WebsocketPort
-
-	// Connect to SDS SP node in a loop
-	for i := 0; i < setting.Config.SDS.ConnectionRetries.Max; i++ {
-		if m.Ctx.Err() != nil {
-			return
-		}
-
-		if i != 0 {
-			time.Sleep(time.Millisecond * time.Duration(setting.Config.SDS.ConnectionRetries.SleepDuration))
-		}
-
-		// Client to subscribe to events from SDS SP node
-		fullSdsWebsocketUrl := "ws://" + sdsWebsocketUrl + "/websocket"
-		sdsTopics := []string{sds.TypeBroadcast}
-		ws := sds.DialWebsocket(fullSdsWebsocketUrl, sdsTopics)
-		if ws == nil {
-			continue
-		}
-		m.sdsWebsocketConn = ws
-
-		go m.sdsEventsReaderLoop()
-		go m.txBroadcasterLoop()
-
-		utils.Log("Successfully subscribed to events from SDS SP node and started client to send messages back")
-		return
-	}
-
-	// This is reached when we couldn't establish the connection to the SP node
-	utils.ErrorLog("Couldn't connect to SDS SP node after many tries. Relayd will shutdown")
-	m.cancel()
-}
-
-func (m *MultiClient) connectToStratosChain() {
-	m.wg.Add(1)
-	defer m.wg.Done()
-	defer func() {
-		if r := recover(); r != nil {
-			utils.ErrorLog("Recovering from panic in stratos-chain connection goroutine", r)
-		}
-	}()
-
-	// Connect to stratos-chain in a loop
-	i := 0
-	for ; i < setting.Config.StratosChain.ConnectionRetries.Max; i++ {
-		if m.Ctx.Err() != nil {
-			return
-		}
-
-		if i != 0 {
-			time.Sleep(time.Millisecond * time.Duration(setting.Config.StratosChain.ConnectionRetries.SleepDuration))
-		}
-
-		err := m.SubscribeToStratosChainEvents()
-		if err != nil {
-			utils.ErrorLog(err)
-			continue
-		}
-
-		utils.Log("Successfully subscribed to events from stratos-chain")
-		return
-	}
-
-	// This is reached when we couldn't establish the connection to the stratos-chain
-	if i == setting.Config.StratosChain.ConnectionRetries.Max {
-		utils.ErrorLog("Couldn't connect to stratos-chain after many tries. Relayd will shutdown")
-	} else {
-		utils.ErrorLog("Couldn't subscribe to stratos-chain events through websockets. Relayd will shutdown")
-	}
-	m.cancel()
-}
-
-func (m *MultiClient) sdsEventsReaderLoop() {
-	m.wg.Add(1)
-	defer func() {
-		if m.Ctx.Err() == nil {
-			go m.connectToSDS()
-		}
-		m.wg.Done()
-	}()
-
-	for {
-		if m.Ctx.Err() != nil {
-			return
-		}
-		_, data, err := m.sdsWebsocketConn.ReadMessage()
-		if err != nil {
-			utils.ErrorLog("error when reading from the SDS websocket", err)
-			return
-		}
-
-		utils.Log("received: " + string(data))
-		msg := protos.RelayMessage{}
-		err = proto.Unmarshal(data, &msg)
-		if err != nil {
-			utils.ErrorLog("couldn't unmarshal message to protos.RelayMessage", err)
-			continue
-		}
-
-		switch msg.Type {
-		case sds.TypeBroadcast:
-			unsignedMsgs := relaytypes.UnsignedMsgs{}
-			err = json.Unmarshal(msg.Data, &unsignedMsgs)
-			if err != nil {
-				utils.ErrorLog("couldn't unmarshal UnsignedMsgs json", err)
-				continue
-			}
-			for _, msgBytes := range unsignedMsgs.Msgs {
-				unsignedMsg, err := msgBytes.FromBytes()
-				if err != nil {
-					utils.ErrorLog(err)
-					continue
-				}
-				// Add unsignedMsg to tx broadcast channel
-				m.txBroadcasterChan <- unsignedMsg
-			}
-		}
-	}
-}
-
-func (m *MultiClient) txBroadcasterLoop() {
-	if m.txBroadcasterChan != nil {
-		// tx broadcaster loop already running
-		return
-	}
-
-	m.wg.Add(1)
-	defer func() {
-		// Close existing channel
-		close(m.txBroadcasterChan)
-		m.txBroadcasterChan = nil
-
-		// If the ctx is not done yet, restart the Tx broadcaster channel
-		if m.Ctx.Err() == nil {
-			go m.txBroadcasterLoop()
-		}
-		m.wg.Done()
-	}()
-
-	m.txBroadcasterChan = make(chan relaytypes.UnsignedMsg, setting.Config.StratosChain.Broadcast.ChannelSize)
-
-	var unsignedMsgs []*relaytypes.UnsignedMsg
-	broadcastTx := func() {
-		utils.Logf("Tx broadcaster loop will try to broadcast %v msgs %v", len(unsignedMsgs), countMsgsByType(unsignedMsgs))
-
-		var unsignedSdkMsgs []sdktypes.Msg
-		protoConfig, txBuilder := createTxConfigAndTxBuilder()
-		for _, unsignedMsg := range unsignedMsgs {
-			unsignedSdkMsgs = append(unsignedSdkMsgs, unsignedMsg.Msg)
-		}
-		defer func() {
-			unsignedMsgs = nil // Clearing msg list
-		}()
-
-		err := setMsgInfoToTxBuilder(txBuilder, unsignedSdkMsgs, 0, "")
-		if err != nil {
-			utils.ErrorLog("couldn't set tx builder", err)
-			return
-		}
-		txBytes, err := stratoschain.BuildTxBytes(protoConfig, txBuilder, setting.Config.BlockchainInfo.ChainId, unsignedMsgs)
-		if err != nil {
-			utils.ErrorLog("couldn't build tx bytes", err)
-			return
-		}
-
-		gasInfo, err := grpc.Simulate(txBytes)
-		if err != nil {
-			utils.ErrorLog("couldn't simulate tx bytes", err)
-			return
-		}
-		gasLimit := uint64(float64(gasInfo.GasUsed) * setting.Config.BlockchainInfo.Transactions.GasAdjustment)
-		txBuilder.SetGasLimit(gasLimit)
-
-		gasPrice, err := types.ParseCoinNormalized(setting.Config.BlockchainInfo.Transactions.GasPrice)
-		if err != nil {
-			utils.ErrorLog("couldn't parse gas price", err)
-			return
-		}
-		feeAmount := gasPrice.Amount.Mul(sdktypes.NewIntFromUint64(gasLimit))
-		fee := sdktypes.NewCoin(gasPrice.Denom, feeAmount)
-		txBuilder.SetFeeAmount(sdktypes.NewCoins(
-			sdktypes.Coin{
-				Denom:  fee.Denom,
-				Amount: fee.Amount,
-			}),
-		)
-
-		txBytes, err = stratoschain.BuildTxBytes(protoConfig, txBuilder, setting.Config.BlockchainInfo.ChainId, unsignedMsgs)
-		if err != nil {
-			utils.ErrorLog("couldn't build tx bytes", err)
-			return
-		}
-
-		err = grpc.BroadcastTx(txBytes, sdktx.BroadcastMode_BROADCAST_MODE_BLOCK)
-		if err != nil {
-			utils.ErrorLog("couldn't broadcast transaction", err)
-			return
-		}
-	}
-
-	for {
-		select {
-		case <-m.Ctx.Done():
-			return
-		case msg, ok := <-m.txBroadcasterChan:
-			if !ok {
-				utils.ErrorLog("The stratos-chain tx broadcaster channel has been closed")
-				return
-			}
-			if msg.Type != "slashing_resource_node" { // Not printing slashing messages, since SP can slash up to 500 PPs at once, polluting the logs
-				utils.DebugLogf("Received a new msg of type [%v] to broadcast! ", msg.Type)
-			}
-			for i := range msg.SignatureKeys {
-				// For messages coming from SP, add the wallet private key that was loaded on start-up
-				if len(msg.SignatureKeys[i].PrivateKey) == 0 && msg.SignatureKeys[i].Address == m.WalletAddress {
-					msg.SignatureKeys[i].PrivateKey = m.WalletPrivateKey.Bytes()
-				}
-			}
-			unsignedMsgs = append(unsignedMsgs, &msg)
-			if len(unsignedMsgs) >= setting.Config.StratosChain.Broadcast.MaxMsgPerTx {
-				// Max broadcast size is reached. Broadcasting now
-				broadcastTx()
-			}
-		case <-time.After(500 * time.Millisecond):
-			// No new messages are waiting to broadcast. Broadcasting existing messages now
-			if len(unsignedMsgs) > 0 {
-				broadcastTx()
-			}
-		}
-	}
-}
-
-func (m *MultiClient) stratosSubscriptionReaderLoop(subscription websocketSubscription, handler func(coretypes.ResultEvent)) {
-	m.wg.Add(1)
-	defer func() {
-		if subscription.client != nil {
-			go func() {
-				err := subscription.client.Unsubscribe(context.Background(), "", subscription.query)
-				if err != nil {
-					utils.ErrorLog("couldn't unsubscribe from "+subscription.query, err)
-				} else {
-					utils.Log("unsubscribed from " + subscription.query)
-				}
-				_ = subscription.client.Stop()
-			}()
-		}
-		m.stratosEventsChannels.Delete(subscription.query)
-		m.wg.Done()
-	}()
-
-	for {
-		select {
-		case <-m.Ctx.Done():
-			return
-		case message, ok := <-subscription.channel:
-			if !ok {
-				utils.Log("The stratos-chain events websocket channel has been closed")
-				return
-			}
-			utils.Logf("Received a new message of type [%v] from stratos-chain!", subscription.query)
-			handler(message)
-		}
-	}
-}
-
-func (m *MultiClient) SubscribeToStratosChain(msgType string) error {
-	handler, ok := handlers.Handlers[msgType]
-	if !ok {
-		return errors.Errorf("Cannot subscribe to message [%v] in stratos-chain: missing handler function", msgType)
-	}
-
-	query := fmt.Sprintf("message.action='%v'", msgType)
-	if _, ok := m.stratosEventsChannels.Load(query); ok {
-		return nil
-	}
-
-	client, err := stratoschain.DialWebsocket(m.stratosWebsocketUrl)
-	if err != nil {
-		return err
-	}
-
-	out, err := client.Subscribe(context.Background(), "", query, 20)
-	if err != nil {
-		return errors.New("failed to subscribe to query in stratos-chain: " + err.Error())
-	}
-
-	subscription := websocketSubscription{
-		channel: out,
-		client:  client,
-		query:   query,
-	}
-	m.stratosEventsChannels.Store(query, subscription)
-	go m.stratosSubscriptionReaderLoop(subscription, handler)
-
-	return nil
-}
-
-func (m *MultiClient) SubscribeToStratosChainEvents() error {
-	for msgType := range handlers.Handlers {
-		err := m.SubscribeToStratosChain(msgType)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (m *MultiClient) GetSdsWebsocketConn() *websocket.Conn {
-	return m.sdsWebsocketConn
-}
-
-func countMsgsByType(unsignedMsgs []*relaytypes.UnsignedMsg) string {
-	msgCount := make(map[string]int)
-	for _, msg := range unsignedMsgs {
-		msgCount[msg.Type]++
-	}
-
-	countString := ""
-	for msgType, count := range msgCount {
-		if countString != "" {
-			countString += ", "
-		}
-		countString += fmt.Sprintf("%v: %v", msgType, count)
-	}
-	return "[" + countString + "]"
-}
-
-func setMsgInfoToTxBuilder(txBuilder client.TxBuilder, txMsg []sdktypes.Msg, gas uint64, memo string) error {
-	err := txBuilder.SetMsgs(txMsg...)
-	if err != nil {
-		return err
-	}
-
-	//txBuilder.SetFeeGranter(tx.FeeGranter())
-	txBuilder.SetGasLimit(gas)
-	txBuilder.SetMemo(memo)
-	return nil
-}
-
-func createTxConfigAndTxBuilder() (client.TxConfig, client.TxBuilder) {
-	protoConfig := authtx.NewTxConfig(relay.ProtoCdc, []signingtypes.SignMode{signingtypes.SignMode_SIGN_MODE_DIRECT})
-	txBuilder := protoConfig.NewTxBuilder()
-	return protoConfig, txBuilder
 }

--- a/relay/client/sds_connection.go
+++ b/relay/client/sds_connection.go
@@ -87,8 +87,8 @@ func (s *sdsConnection) refresh() {
 
 	// Schedule next connection refresh
 	if setting.Config.SDS.ConnectionRetries.RefreshInterval > 0 {
+		s.wg.Add(1)
 		go func() {
-			s.wg.Add(1)
 			defer s.wg.Done()
 
 			select {

--- a/relay/client/sds_connection.go
+++ b/relay/client/sds_connection.go
@@ -1,0 +1,338 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+	"github.com/gorilla/websocket"
+	"github.com/stratosnet/sds/cmd/relayd/setting"
+	"github.com/stratosnet/sds/msg/protos"
+	"github.com/stratosnet/sds/relay"
+	"github.com/stratosnet/sds/relay/sds"
+	"github.com/stratosnet/sds/relay/stratoschain"
+	"github.com/stratosnet/sds/relay/stratoschain/grpc"
+	relaytypes "github.com/stratosnet/sds/relay/types"
+	"github.com/stratosnet/sds/utils"
+	"github.com/stratosnet/sds/utils/types"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	txBroadcastMaxInterval = 500 // milliseconds
+)
+
+type sdsConnection struct {
+	client *MultiClient
+
+	sdsWebsocketConn  *websocket.Conn
+	txBroadcasterChan chan relaytypes.UnsignedMsg
+
+	cancel context.CancelFunc
+	ctx    context.Context
+	once   *sync.Once
+	wg     *sync.WaitGroup
+	mux    sync.Mutex
+}
+
+func newSdsConnection(client *MultiClient) *sdsConnection {
+	return &sdsConnection{
+		client: client,
+	}
+}
+
+func (s *sdsConnection) stop() {
+	if s.once == nil {
+		return
+	}
+
+	s.once.Do(func() {
+		s.cancel()
+
+		if s.sdsWebsocketConn != nil {
+			_ = s.sdsWebsocketConn.Close()
+		}
+
+		if s.txBroadcasterChan != nil {
+			close(s.txBroadcasterChan)
+			s.txBroadcasterChan = nil
+		}
+
+		s.wg.Wait()
+		utils.Log("sds connection has been stopped")
+	})
+}
+
+func (s *sdsConnection) refresh() {
+	if !s.mux.TryLock() {
+		return // Refresh procedure already started
+	}
+	defer s.mux.Unlock()
+
+	s.stop() // Stop the connection if it was started before
+
+	s.ctx, s.cancel = context.WithCancel(s.client.Ctx)
+	s.once = &sync.Once{}
+	s.wg = &sync.WaitGroup{}
+
+	s.wg.Add(1)
+	defer s.wg.Done()
+
+	// Schedule next connection refresh
+	if setting.Config.SDS.ConnectionRetries.RefreshInterval > 0 {
+		go func() {
+			s.wg.Add(1)
+			defer s.wg.Done()
+
+			select {
+			case <-time.After(time.Duration(setting.Config.SDS.ConnectionRetries.RefreshInterval) * time.Second):
+				utils.Logf("sds connection has been alive for a long time and will be refreshed")
+				go s.refresh()
+			case <-s.ctx.Done():
+				return
+			}
+		}()
+	}
+
+	sdsWebsocketUrl := setting.Config.SDS.NetworkAddress + ":" + setting.Config.SDS.WebsocketPort
+
+	// Connect to SDS SP node in a loop
+	i := 0
+	for ; i < setting.Config.SDS.ConnectionRetries.Max; i++ {
+		if s.ctx.Err() != nil {
+			return
+		}
+
+		if i != 0 {
+			time.Sleep(time.Millisecond * time.Duration(setting.Config.SDS.ConnectionRetries.SleepDuration))
+		}
+
+		// Client to subscribe to events from SDS SP node
+		fullSdsWebsocketUrl := "ws://" + sdsWebsocketUrl + "/websocket"
+		sdsTopics := []string{sds.TypeBroadcast}
+		ws := sds.DialWebsocket(fullSdsWebsocketUrl, sdsTopics)
+		if ws == nil {
+			continue
+		}
+		s.sdsWebsocketConn = ws
+
+		go s.sdsEventsReaderLoop()
+		go s.txBroadcasterLoop()
+
+		utils.Log("Successfully subscribed to events from SDS SP node and started client to send messages back")
+		return
+	}
+
+	// This is reached when we couldn't establish the connection to the SP node
+	if i == setting.Config.SDS.ConnectionRetries.Max {
+		utils.ErrorLog("Couldn't connect to SDS SP node after many tries. Relayd will shutdown")
+	} else {
+		utils.ErrorLog("Couldn't subscribe to SDS SP node. Relayd will shutdown")
+	}
+	s.client.cancel() // Cancel global context
+}
+
+func (s *sdsConnection) sdsEventsReaderLoop() {
+	s.wg.Add(1)
+
+	defer func() {
+		if r := recover(); r != nil {
+			utils.ErrorLog("Recovering from panic in sds events reader loop", r)
+		}
+
+		s.wg.Done()
+		go s.refresh()
+	}()
+
+	for {
+		if s.ctx.Err() != nil {
+			return
+		}
+		_, data, err := s.sdsWebsocketConn.ReadMessage()
+		if err != nil {
+			utils.ErrorLog("error when reading from the SDS websocket", err)
+			return
+		}
+
+		utils.Log("received: " + string(data))
+		msg := protos.RelayMessage{}
+		err = proto.Unmarshal(data, &msg)
+		if err != nil {
+			utils.ErrorLog("couldn't unmarshal message to protos.RelayMessage", err)
+			continue
+		}
+
+		switch msg.Type {
+		case sds.TypeBroadcast:
+			unsignedMsgs := relaytypes.UnsignedMsgs{}
+			err = json.Unmarshal(msg.Data, &unsignedMsgs)
+			if err != nil {
+				utils.ErrorLog("couldn't unmarshal UnsignedMsgs json", err)
+				continue
+			}
+			for _, msgBytes := range unsignedMsgs.Msgs {
+				unsignedMsg, err := msgBytes.FromBytes()
+				if err != nil {
+					utils.ErrorLog(err)
+					continue
+				}
+				// Add unsignedMsg to tx broadcast channel
+				s.txBroadcasterChan <- unsignedMsg
+			}
+		}
+	}
+}
+
+func (s *sdsConnection) txBroadcasterLoop() {
+	if s.txBroadcasterChan != nil {
+		// tx broadcaster loop already running
+		return
+	}
+
+	s.wg.Add(1)
+
+	defer func() {
+		if r := recover(); r != nil {
+			utils.ErrorLog("Recovering from panic in sds tx broadcaster loop", r)
+		}
+
+		s.wg.Done()
+		go s.refresh()
+	}()
+
+	s.txBroadcasterChan = make(chan relaytypes.UnsignedMsg, setting.Config.StratosChain.Broadcast.ChannelSize)
+
+	var unsignedMsgs []*relaytypes.UnsignedMsg
+	broadcastTxs := func() {
+		utils.Logf("Tx broadcaster loop will try to broadcast %v msgs %v", len(unsignedMsgs), countMsgsByType(unsignedMsgs))
+
+		var unsignedSdkMsgs []sdktypes.Msg
+		protoConfig, txBuilder := createTxConfigAndTxBuilder()
+		for _, unsignedMsg := range unsignedMsgs {
+			unsignedSdkMsgs = append(unsignedSdkMsgs, unsignedMsg.Msg)
+		}
+		defer func() {
+			unsignedMsgs = nil // Clearing msg list
+		}()
+
+		err := setMsgInfoToTxBuilder(txBuilder, unsignedSdkMsgs, 0, "")
+		if err != nil {
+			utils.ErrorLog("couldn't set tx builder", err)
+			return
+		}
+		txBytes, err := stratoschain.BuildTxBytes(protoConfig, txBuilder, setting.Config.BlockchainInfo.ChainId, unsignedMsgs)
+		if err != nil {
+			utils.ErrorLog("couldn't build tx bytes", err)
+			return
+		}
+
+		gasInfo, err := grpc.Simulate(txBytes)
+		if err != nil {
+			utils.ErrorLog("couldn't simulate tx bytes", err)
+			return
+		}
+		gasLimit := uint64(float64(gasInfo.GasUsed) * setting.Config.BlockchainInfo.Transactions.GasAdjustment)
+		txBuilder.SetGasLimit(gasLimit)
+
+		gasPrice, err := types.ParseCoinNormalized(setting.Config.BlockchainInfo.Transactions.GasPrice)
+		if err != nil {
+			utils.ErrorLog("couldn't parse gas price", err)
+			return
+		}
+		feeAmount := gasPrice.Amount.Mul(sdktypes.NewIntFromUint64(gasLimit))
+		fee := sdktypes.NewCoin(gasPrice.Denom, feeAmount)
+		txBuilder.SetFeeAmount(sdktypes.NewCoins(
+			sdktypes.Coin{
+				Denom:  fee.Denom,
+				Amount: fee.Amount,
+			}),
+		)
+
+		txBytes, err = stratoschain.BuildTxBytes(protoConfig, txBuilder, setting.Config.BlockchainInfo.ChainId, unsignedMsgs)
+		if err != nil {
+			utils.ErrorLog("couldn't build tx bytes", err)
+			return
+		}
+
+		err = grpc.BroadcastTx(txBytes, sdktx.BroadcastMode_BROADCAST_MODE_BLOCK)
+		if err != nil {
+			utils.ErrorLog("couldn't broadcast transaction", err)
+			return
+		}
+	}
+
+	timeOver := time.After(txBroadcastMaxInterval * time.Millisecond)
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case msg, ok := <-s.txBroadcasterChan:
+			if !ok {
+				utils.ErrorLog("The stratos-chain tx broadcaster channel has been closed")
+				return
+			}
+			if msg.Type != "slashing_resource_node" { // Not printing slashing messages, since SP can slash up to 500 PPs at once, polluting the logs
+				utils.DebugLogf("Received a new msg of type [%v] to broadcast! ", msg.Type)
+			}
+			for i := range msg.SignatureKeys {
+				// For messages coming from SP, add the wallet private key that was loaded on start-up
+				if len(msg.SignatureKeys[i].PrivateKey) == 0 && msg.SignatureKeys[i].Address == s.client.WalletAddress {
+					msg.SignatureKeys[i].PrivateKey = s.client.WalletPrivateKey.Bytes()
+				}
+			}
+			unsignedMsgs = append(unsignedMsgs, &msg)
+			if len(unsignedMsgs) >= setting.Config.StratosChain.Broadcast.MaxMsgPerTx {
+				// Max broadcast size is reached. Broadcasting now
+				broadcastTxs()
+				timeOver = time.After(txBroadcastMaxInterval * time.Millisecond)
+			}
+		case <-timeOver:
+			// No new messages are waiting to broadcast. Broadcasting existing messages now
+			if len(unsignedMsgs) > 0 {
+				broadcastTxs()
+				timeOver = time.After(txBroadcastMaxInterval * time.Millisecond)
+			}
+		}
+	}
+}
+
+func countMsgsByType(unsignedMsgs []*relaytypes.UnsignedMsg) string {
+	msgCount := make(map[string]int)
+	for _, msg := range unsignedMsgs {
+		msgCount[msg.Type]++
+	}
+
+	countString := ""
+	for msgType, count := range msgCount {
+		if countString != "" {
+			countString += ", "
+		}
+		countString += fmt.Sprintf("%v: %v", msgType, count)
+	}
+	return "[" + countString + "]"
+}
+
+func setMsgInfoToTxBuilder(txBuilder client.TxBuilder, txMsg []sdktypes.Msg, gas uint64, memo string) error {
+	err := txBuilder.SetMsgs(txMsg...)
+	if err != nil {
+		return err
+	}
+
+	//txBuilder.SetFeeGranter(tx.FeeGranter())
+	txBuilder.SetGasLimit(gas)
+	txBuilder.SetMemo(memo)
+	return nil
+}
+
+func createTxConfigAndTxBuilder() (client.TxConfig, client.TxBuilder) {
+	protoConfig := authtx.NewTxConfig(relay.ProtoCdc, []signingtypes.SignMode{signingtypes.SignMode_SIGN_MODE_DIRECT})
+	txBuilder := protoConfig.NewTxBuilder()
+	return protoConfig, txBuilder
+}

--- a/relay/client/sds_connection.go
+++ b/relay/client/sds_connection.go
@@ -297,8 +297,8 @@ func (s *sdsConnection) txBroadcasterLoop() {
 			// No new messages are waiting to broadcast. Broadcasting existing messages now
 			if len(unsignedMsgs) > 0 {
 				broadcastTxs()
-				timeOver = time.After(txBroadcastMaxInterval * time.Millisecond)
 			}
+			timeOver = time.After(txBroadcastMaxInterval * time.Millisecond)
 		}
 	}
 }

--- a/relay/client/stchain_connection.go
+++ b/relay/client/stchain_connection.go
@@ -55,8 +55,8 @@ func (s *stchainConnection) stop() {
 				return false
 			}
 
+			s.wg.Add(1)
 			go func() {
-				s.wg.Add(1)
 				defer s.wg.Done()
 
 				if subscription.client == nil {
@@ -96,8 +96,8 @@ func (s *stchainConnection) refresh() {
 
 	// Schedule next connection refresh
 	if setting.Config.StratosChain.ConnectionRetries.RefreshInterval > 0 {
+		s.wg.Add(1)
 		go func() {
-			s.wg.Add(1)
 			defer s.wg.Done()
 
 			select {

--- a/relay/client/stchain_connection.go
+++ b/relay/client/stchain_connection.go
@@ -1,0 +1,210 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stratosnet/sds/cmd/relayd/setting"
+	"github.com/stratosnet/sds/relay/stratoschain"
+	"github.com/stratosnet/sds/relay/stratoschain/handlers"
+	"github.com/stratosnet/sds/utils"
+	tmHttp "github.com/tendermint/tendermint/rpc/client/http"
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
+)
+
+// stchainConnection is used to subscribe to stratos-chain events and receive messages via websocket
+type stchainConnection struct {
+	client *MultiClient
+
+	stratosEventsChannels *sync.Map
+
+	cancel context.CancelFunc
+	ctx    context.Context
+	once   *sync.Once
+	wg     *sync.WaitGroup
+	mux    sync.Mutex
+}
+
+type websocketSubscription struct {
+	channel <-chan coretypes.ResultEvent
+	client  *tmHttp.HTTP
+	query   string
+}
+
+func newStchainConnection(client *MultiClient) *stchainConnection {
+	return &stchainConnection{
+		client:                client,
+		stratosEventsChannels: &sync.Map{},
+	}
+}
+
+func (s *stchainConnection) stop() {
+	if s.once == nil {
+		return
+	}
+
+	s.once.Do(func() {
+		s.cancel()
+
+		s.stratosEventsChannels.Range(func(k, v interface{}) bool {
+			subscription, ok := v.(websocketSubscription)
+			if !ok {
+				return false
+			}
+
+			go func() {
+				s.wg.Add(1)
+				defer s.wg.Done()
+
+				if subscription.client == nil {
+					return
+				}
+
+				err := subscription.client.Unsubscribe(context.Background(), "", subscription.query)
+				if err != nil {
+					utils.ErrorLog("couldn't unsubscribe from "+subscription.query, err)
+				} else {
+					utils.DetailLog("unsubscribed from " + subscription.query)
+				}
+				_ = subscription.client.Stop()
+			}()
+			return false
+		})
+
+		s.wg.Wait()
+		utils.Log("stchain connection has been stopped")
+	})
+}
+
+func (s *stchainConnection) refresh() {
+	if !s.mux.TryLock() {
+		return // Refresh procedure already started
+	}
+	defer s.mux.Unlock()
+
+	s.stop() // Stop the connection if it was started before
+
+	s.ctx, s.cancel = context.WithCancel(s.client.Ctx)
+	s.once = &sync.Once{}
+	s.wg = &sync.WaitGroup{}
+
+	s.wg.Add(1)
+	defer s.wg.Done()
+
+	// Schedule next connection refresh
+	if setting.Config.StratosChain.ConnectionRetries.RefreshInterval > 0 {
+		go func() {
+			s.wg.Add(1)
+			defer s.wg.Done()
+
+			select {
+			case <-time.After(time.Duration(setting.Config.StratosChain.ConnectionRetries.RefreshInterval) * time.Second):
+				utils.Logf("stchain connection has been alive for a long time and will be refreshed")
+				go s.refresh()
+			case <-s.ctx.Done():
+				return
+			}
+		}()
+	}
+
+	// Connect to stratos-chain in a loop
+	i := 0
+	for ; i < setting.Config.StratosChain.ConnectionRetries.Max; i++ {
+		if s.ctx.Err() != nil {
+			return
+		}
+
+		if i != 0 {
+			time.Sleep(time.Millisecond * time.Duration(setting.Config.StratosChain.ConnectionRetries.SleepDuration))
+		}
+
+		err := s.subscribeToStratosChainEvents()
+		if err != nil {
+			utils.ErrorLog(err)
+			continue
+		}
+
+		utils.Log("Successfully subscribed to events from stratos-chain")
+		return
+	}
+
+	// This is reached when we couldn't establish the connection to the stratos-chain
+	if i == setting.Config.StratosChain.ConnectionRetries.Max {
+		utils.ErrorLog("Couldn't connect to stratos-chain after many tries. Relayd will shutdown")
+	} else {
+		utils.ErrorLog("Couldn't subscribe to stratos-chain events through websockets. Relayd will shutdown")
+	}
+	s.client.cancel() // Cancel global context
+}
+
+func (s *stchainConnection) stratosSubscriptionReaderLoop(subscription websocketSubscription, handler func(coretypes.ResultEvent)) {
+	s.wg.Add(1)
+
+	defer func() {
+		if r := recover(); r != nil {
+			utils.ErrorLog("Recovering from panic in stratos-chain subscription reader loop", r)
+		}
+
+		s.wg.Done()
+		go s.refresh()
+	}()
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case message, ok := <-subscription.channel:
+			if !ok {
+				utils.Log("The stratos-chain events websocket channel has been closed")
+				return
+			}
+			utils.Logf("Received a new message of type [%v] from stratos-chain!", subscription.query)
+			handler(message)
+		}
+	}
+}
+
+func (s *stchainConnection) subscribeToStratosChain(msgType string) error {
+	handler, ok := handlers.Handlers[msgType]
+	if !ok {
+		return errors.Errorf("Cannot subscribe to message [%v] in stratos-chain: missing handler function", msgType)
+	}
+
+	query := fmt.Sprintf("message.action='%v'", msgType)
+	if _, ok := s.stratosEventsChannels.Load(query); ok {
+		return nil
+	}
+
+	client, err := stratoschain.DialWebsocket(setting.Config.StratosChain.WebsocketServer)
+	if err != nil {
+		return err
+	}
+
+	out, err := client.Subscribe(context.Background(), "", query, 20)
+	if err != nil {
+		return errors.New("failed to subscribe to query in stratos-chain: " + err.Error())
+	}
+
+	subscription := websocketSubscription{
+		channel: out,
+		client:  client,
+		query:   query,
+	}
+	s.stratosEventsChannels.Store(query, subscription)
+	go s.stratosSubscriptionReaderLoop(subscription, handler)
+
+	return nil
+}
+
+func (s *stchainConnection) subscribeToStratosChainEvents() error {
+	for msgType := range handlers.Handlers {
+		err := s.subscribeToStratosChain(msgType)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-1990
https://qsn.atlassian.net/browse/QB-2019

- refactor relayd to split sds and stchain connection code away from the multiclient code
- sds and stchain connections (relayd) now get refreshed automatically after enough time has passed
- added `sds.connection_retries.refresh_interval` and `stratos_chain.connection_retries.refresh_interval` relayd configs
- added `monitor.allowed_origins` ppd config, so node owners can specify who can connect to their monitor port