### PR TITLE
fix/QB-2039 Remove terminal login cmd

### DIFF
--- a/cmd/ppd/terminal.go
+++ b/cmd/ppd/terminal.go
@@ -35,7 +35,6 @@ func run(cmd *cobra.Command, args []string, isExec bool) {
 		"help                                                           show all the commands\n" +
 		"wallets                                                        acquire all wallet wallets' address\n" +
 		"newwallet                                                      create new wallet, input password in prompt\n" +
-		"login <walletAddress> ->password                               unlock and log in wallet, input password in prompt\n" +
 		"registerpeer                                                   register peer to index node\n" +
 		"rp                                                             register peer to index node\n" +
 		"activate <amount> <fee> optional<gas>                          send transaction to stchain to become an active PP node\n" +
@@ -96,20 +95,6 @@ func run(cmd *cobra.Command, args []string, isExec bool) {
 			return false
 		}
 		return true
-	}
-
-	login := func(line string, param []string) bool {
-		if len(param) < 1 {
-			fmt.Println("input wallet address")
-			return false
-		}
-		if len(param[0]) != 41 {
-			fmt.Println("input correct wallet address")
-			return false
-		}
-		password := console.MyGetPassword("input password", false)
-
-		return callRpc(c, "login", []string{param[0], password})
 	}
 
 	start := func(line string, param []string) bool {
@@ -256,7 +241,6 @@ func run(cmd *cobra.Command, args []string, isExec bool) {
 	console.Mystdin.RegisterProcessFunc("wallets", wallets, false)
 	console.Mystdin.RegisterProcessFunc("getoz", getoz, true)
 	console.Mystdin.RegisterProcessFunc("newwallet", newwallet, false)
-	console.Mystdin.RegisterProcessFunc("login", login, false)
 	console.Mystdin.RegisterProcessFunc("startmining", start, true)
 	console.Mystdin.RegisterProcessFunc("rp", registerPP, true)
 	console.Mystdin.RegisterProcessFunc("registerpeer", registerPP, true)

--- a/pp/setting/setting.go
+++ b/pp/setting/setting.go
@@ -189,13 +189,15 @@ func SetConfig(key string, value interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err = toml.Unmarshal(data, &config{}); err != nil {
+
+	updatedConfig := &config{}
+	if err = toml.Unmarshal(data, updatedConfig); err != nil {
 		return err
 	}
 
 	// Save changes to file
-	err = os.WriteFile(ConfigPath, data, 0644)
-	if err != nil {
+	Config = updatedConfig
+	if err = FlushConfig(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-2039

- removed obsolete login cmd from terminal
- fixed terminal config cmd so it doesn't change the toml comments and formatting after updating a key/value pair 