### PR TITLE
fix/QB-2100 handshake sends node IP in first msg

### DIFF
--- a/framework/core/conn.go
+++ b/framework/core/conn.go
@@ -145,6 +145,10 @@ func (sc *ServerConn) GetRemoteNetworkAddress() string {
 	return sc.remoteNetworkAddress
 }
 
+func (sc *ServerConn) SetRemoteNetworkAddress(networkAddress string) {
+	sc.remoteNetworkAddress = networkAddress
+}
+
 func (sc *ServerConn) GetLocalP2pAddress() string {
 	return sc.belong.opts.p2pAddress
 }

--- a/framework/core/types.go
+++ b/framework/core/types.go
@@ -3,7 +3,7 @@ package core
 const (
 	// This is either a client creating a connection, or a temporary connection made for a handshake
 	// Read the first message from the connection. It should indicate what kind of connection it is
-	ConnFirstMsgSize  = 14 // Conn type (8) + server port (2) + channel ID (4)
+	ConnFirstMsgSize  = 30 // Conn type (8) + IP (16) + server port (2) + channel ID (4)
 	ConnTypeClient    = "client__"
 	ConnTypeHandshake = "handshke"
 

--- a/pp/p2pserver/client.go
+++ b/pp/p2pserver/client.go
@@ -108,6 +108,7 @@ func (p *P2pServer) newClient(ctx context.Context, server string, heartbeat, rec
 		cf.LogOpenOption(true),
 		cf.MinAppVersionOption(setting.Config.Version.MinAppVer),
 		cf.P2pAddressOption(p.GetP2PAddress()),
+		cf.ServerIpOption(setting.NetworkIP),
 		serverPortOpt,
 		cf.ContextKVOption(ckv),
 	}

--- a/pp/setting/ppinfo.go
+++ b/pp/setting/ppinfo.go
@@ -26,6 +26,8 @@ var WalletPrivateKey []byte
 
 var NetworkAddress string
 
+var NetworkIP net.IP
+
 var RestAddress string
 
 var MonitorInitialToken string
@@ -60,6 +62,7 @@ func SetMyNetworkAddress() {
 	if netAddr != "" {
 		NetworkAddress = netAddr + ":" + Config.Node.Connectivity.NetworkPort
 		RestAddress = netAddr + ":" + Config.Streaming.RestPort
+		NetworkIP = net.ParseIP(netAddr)
 	}
 	utils.Log("setting.NetworkAddress", NetworkAddress)
 }


### PR DESCRIPTION
https://qsn.atlassian.net/browse/QB-2100
Merge at the same time as [this SP PR](https://github.com/stratosnet/sp/pull/482)

- Send node IP in first msg during handshake, and use it when creating secondary handshake connection
- Add comment for server `GetRemoteAddr` to warn that it might be the wrong IP when using VMs