### PR TITLE
fix/QB-2146 condition check finishing of download is improved

### DIFF
--- a/pp/event/download_file_wrong.go
+++ b/pp/event/download_file_wrong.go
@@ -60,7 +60,7 @@ func RspDownloadFileWrong(ctx context.Context, conn core.WriteCloser) {
 				return
 			}
 			for _, slice := range target.SliceInfo {
-				utils.DebugLog(ctx, "taskid ======= ", slice.TaskId)
+				utils.DebugLog("taskid ======= ", slice.TaskId)
 				if file.CheckSliceExisting(target.FileHash, target.FileName, slice.SliceStorageInfo.SliceHash, fileReqId) {
 					pp.Log(ctx, "slice exist already,", slice.SliceStorageInfo.SliceHash)
 					setDownloadSliceSuccess(ctx, slice.SliceStorageInfo.SliceHash, dTask)
@@ -75,7 +75,7 @@ func RspDownloadFileWrong(ctx context.Context, conn core.WriteCloser) {
 			pp.DebugLog(ctx, "DownloadFileSlice(&target)", &target)
 		} else {
 			task.DeleteDownloadTask(target.FileHash, target.WalletAddress, task.LOCAL_REQID)
-			task.LogDownloadResult(ctx, target.FileHash, false, target.Result.Msg)
+			task.DownloadResult(ctx, target.FileHash, false, target.Result.Msg)
 		}
 	}
 }

--- a/pp/event/download_slice.go
+++ b/pp/event/download_slice.go
@@ -530,7 +530,7 @@ func DownloadFileSlices(ctx context.Context, target *protos.RspFileStorageInfo, 
 				"\nslicenumber: ", slice.SliceNumber, "\n result:", re)
 		}
 	} else {
-		task.LogDownloadResult(ctx, target.FileHash, false, "file exists already.")
+		task.DownloadResult(ctx, target.FileHash, false, "file exists already.")
 		task.DeleteDownloadTask(target.FileHash, target.WalletAddress, target.ReqId)
 	}
 }

--- a/pp/event/query_file_info.go
+++ b/pp/event/query_file_info.go
@@ -134,8 +134,7 @@ func RspFileStorageInfo(ctx context.Context, conn core.WriteCloser) {
 	fileReqId := core.GetRemoteReqId(ctx)
 	rpcRequested := !strings.HasPrefix(fileReqId, task.LOCAL_REQID)
 	if target.Result.State == protos.ResultState_RES_FAIL {
-		task.SetDownloadResultToRpc(target.FileHash, false)
-		task.LogDownloadResult(ctx, target.FileHash, false, "failed ReqFileStorageInfo, "+target.Result.Msg)
+		task.DownloadResult(ctx, target.FileHash, false, "failed ReqFileStorageInfo, "+target.Result.Msg)
 		if rpcRequested {
 			file.SetRemoteFileResult(target.FileHash+fileReqId, rpc.Result{Return: rpc.FILE_REQ_FAILURE})
 		}


### PR DESCRIPTION
When the messages are buffered in storage pps, and the retry mechanism is triggered. There is chance that some replicated packets come after 100% is reached. For instance, there are 10 messages calls CheckDownloadOver(). All of them got blocked at time consuming operations, e.g. copying file from tmp/download  to ./download.

To prevent this from happening, a mutex is added to block messages after the first one before load from DownloadSpeedOfProgress. 