### PR TITLE
fix/qb2144: fix abnormal download progress percentage caused by retrying a download

### DIFF
--- a/pp/event/download_file_wrong.go
+++ b/pp/event/download_file_wrong.go
@@ -67,6 +67,7 @@ func RspDownloadFileWrong(ctx context.Context, conn core.WriteCloser) {
 					task.DownloadProgress(ctx, target.FileHash, fileReqId, slice.SliceOffset.SliceOffsetEnd-slice.SliceOffset.SliceOffsetStart)
 				} else {
 					pp.DebugLog(ctx, "request download data")
+					task.DownloadSliceProgress.Store(slice.SliceStorageInfo.SliceHash+fileReqId, uint64(0))
 					req := requests.ReqDownloadSliceData(ctx, &target, slice)
 					newCtx := createAndRegisterSliceReqId(ctx, fileReqId)
 					SendReqDownloadSlice(newCtx, target.FileHash, slice, req, fileReqId)


### PR DESCRIPTION
- qb2144： download progress is now updated only after whole slice gets downloaded (vs update by packet), in order to avoid duplicate percentage counts
- qb2144: retrying failedSlices in download_file_fail response will first clear previous DownloadSliceProgress