### PR TITLE
fix/QB-2196 adjust buffer pool size

### DIFF
--- a/pp/setting/constants.go
+++ b/pp/setting/constants.go
@@ -17,7 +17,7 @@ const (
 
 	NodeReportIntervalSec         = 5 * 60 // Interval of node stat report, in seconds
 	PpLatencyCheckInterval        = 60     // interval for checking the latency to next PP
-	DEFAULT_DATA_BUFFER_POOL_SIZE = 2000
+	DEFAULT_DATA_BUFFER_POOL_SIZE = 200
 
 	MaxData            = 1024 * 1024 * 3 // max size of a piece in a slice
 	MaxSliceSize       = 1024 * 1024 * 32


### PR DESCRIPTION
In fact, the value in environment variable PPD_DATA_BUF_SIZE is used no matter in dev or product environment.