### PR TITLE
feat/ST-402 Domain name support

### DIFF
--- a/example/network/node1/config/config.toml
+++ b/example/network/node1/config/config.toml
@@ -1,20 +1,20 @@
 [version]
-# App version number. Eg: 9
+# App version number. Eg: 11
 app_ver = 12
-# Network connections from nodes below this version number will be rejected. Eg: 9
+# Network connections from nodes below this version number will be rejected. Eg: 11
 min_app_ver = 12
-# Formatted version number. Eg: "v0.9.0"
+# Formatted version number. Eg: "v0.11.0"
 show = 'v0.12.0'
 
 # Configuration of the connection to the Stratos blockchain
 [blockchain]
-# ID of the chain Eg: "tropos-5"
+# ID of the chain Eg: "stratos-1"
 chain_id = 'testchain'
 # Multiplier for the simulated tx gas cost Eg: 1.5
 gas_adjustment = 1.3
 # Connect to the chain using an insecure connection (no TLS) Eg: true
 insecure = true
-# Network address of the chain Eg: "127.0.0.1:9090"
+# Network address of the chain grpc Eg: "127.0.0.1:9090"
 grpc_server = '127.0.0.1:9090'
 
 # Structure of the home folder. Default paths (eg: "./storage" become relative to the node home. Other paths are relative to the working directory
@@ -35,23 +35,25 @@ p2p_password = 'aaa'
 # Address of the stratos wallet. Eg: "stxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 wallet_address = 'st1sqzsk8mplv5248gx6dddzzxweqvew8rtst96fx'
 wallet_password = 'aaa'
-# "Address for receiving reward. Eg: \"stxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"
+# Address for receiving reward. Eg: "stxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 beneficiary_address = 'st1sqzsk8mplv5248gx6dddzzxweqvew8rtst96fx'
 
 # Configuration of this node
 [node]
 # Should debug info be printed out in logs? Eg: false
 debug = true
-# When not 0, limit disk usage to this amount (in megabytes) Eg: 1048576 (1 TB)
+# When not 0, limit disk usage to this amount (in megabytes) Eg: 7629394 = 8 * 1000 * 1000 * 1000 * 1000 / 1024 / 1024  (8TB) 
 max_disk_usage = 1048576
 
 [node.connectivity]
 # Is the node running on an internal network? Eg: false
 internal = false
-# IP address of the node. Eg: "127.0.0.1"
+# Domain name or IP address of the node. Eg: "127.0.0.1"
 network_address = '127.0.0.1'
 # Main port for communication on the network. Must be open to the internet. Eg: "18081"
 network_port = '9101'
+# (Optional)If not empty, the node will listen to this port locally, but other nodes will still use the network_port to connect to this node
+local_port = ''
 # Port for prometheus metrics
 metrics_port = '9201'
 # Port for the JSON-RPC api. See https://docs.thestratos.org/docs-resource-node/sds-rpc-for-file-operation/
@@ -75,7 +77,7 @@ cert_file_path = ''
 key_file_path = ''
 # Port used for the monitor websocket connection. It's the monitor UI that uses this port, not the person accessing the UI in a browser
 port = '9401'
-# List of IPs that are allowed to connect to the monitor websocket port
+# List of IPs that are allowed to connect to the monitor websocket port. This is used to decide which IP can connect their monitor to the node, NOT to decide who can view the monitor UI page.
 allowed_origins = ['localhost']
 
 # Configuration for video streaming
@@ -101,5 +103,5 @@ max_upload_rate = 0
 path = './web'
 # Port where the web server is hosted with sdsweb. If the port is opened and token_on_startup is true, anybody who loads the monitor UI will have full access to the monitor
 port = '9701'
-# Automatically enter monitor token when opening the monitor UI. This should be false if the web_server port is opened
+# Automatically enter monitor token when opening the monitor UI. This should be false if the web_server port is opened to internet and you don't want public access to your node monitor'
 token_on_startup = true

--- a/pp/event/register_to_sp.go
+++ b/pp/event/register_to_sp.go
@@ -76,7 +76,7 @@ func RspMining(ctx context.Context, conn core.WriteCloser) {
 
 	pp.Log(ctx, "start mining")
 	if p2pserver.GetP2pServer(ctx).GetP2pServer() == nil {
-		go p2pserver.GetP2pServer(ctx).StartListenServer(ctx, setting.Config.Node.Connectivity.NetworkPort)
+		go p2pserver.GetP2pServer(ctx).StartListenServer(ctx, setting.GetP2pServerPort())
 	}
 	pp.DebugLog(ctx, "Start reporting node status to SP")
 	// trigger 1 stat report immediately

--- a/pp/p2pserver/pp.go
+++ b/pp/p2pserver/pp.go
@@ -163,7 +163,7 @@ func (p *P2pServer) Start(ctx context.Context) {
 
 	ctx = p.initQuitChs(ctx)
 	setting.SetMyNetworkAddress()
-	go p.StartListenServer(ctx, setting.Config.Node.Connectivity.NetworkPort)
+	go p.StartListenServer(ctx, setting.GetP2pServerPort())
 	p.initClient()
 }
 

--- a/pp/setting/setting.go
+++ b/pp/setting/setting.go
@@ -93,8 +93,9 @@ type KeysConfig struct {
 type ConnectivityConfig struct {
 	SeedMetaNode   SPBaseInfo `toml:"seed_meta_node" comment:"The first meta node to connect to when starting the node"`
 	Internal       bool       `toml:"internal" comment:"Is the node running on an internal network? Eg: false"`
-	NetworkAddress string     `toml:"network_address" comment:"IP address of the node. Eg: \"127.0.0.1\""`
+	NetworkAddress string     `toml:"network_address" comment:"Domain name or IP address of the node. Eg: \"127.0.0.1\""`
 	NetworkPort    string     `toml:"network_port" comment:"Main port for communication on the network. Must be open to the internet. Eg: \"18081\""`
+	LocalPort      string     `toml:"local_port" comment:"(Optional)If not empty, the node will listen to this port locally, but other nodes will still use the network_port to connect to this node"`
 	MetricsPort    string     `toml:"metrics_port" comment:"Port for prometheus metrics"`
 	RpcPort        string     `toml:"rpc_port" comment:"Port for the JSON-RPC api. See https://docs.thestratos.org/docs-resource-node/sds-rpc-for-file-operation/"`
 	RpcNamespaces  string     `toml:"rpc_namespaces" comment:"Namespaces enabled in the RPC API. Eg: \"user,owner\""`
@@ -276,6 +277,7 @@ func DefaultConfig() *config {
 				Internal:       false,
 				NetworkAddress: "127.0.0.1",
 				NetworkPort:    "18081",
+				LocalPort:      "",
 				MetricsPort:    "18181",
 				RpcPort:        "18281",
 				RpcNamespaces:  "user",


### PR DESCRIPTION
https://qsn.atlassian.net/browse/ST-402

- support domain names as network address by resolving them to an IP address
- added `local_port` config. If not empty, the node will locally listen to this port for new connections
  - other nodes will still use `network_port` to connect to this node
  - this can be helpful when working with VMs or tunnels/proxies (eg: ngrok)