### PR TITLE
fix/ST-447 resend failed download req

### DIFF
--- a/pp/event/download_file_wrong.go
+++ b/pp/event/download_file_wrong.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	ResendFailedDownloadDelay     = 5  // Seconds
-	ResendFailedDownloadTimeLimit = 30 // Seconds. If this time has elapsed since the start of the download task, don't resend the ReqDownloadFileWrong
+	ResendFailedDownloadDelay     = 5   // Seconds
+	ResendFailedDownloadTimeLimit = 120 // Seconds. If this time has elapsed since the start of the download task, don't resend the ReqDownloadFileWrong
 )
 
 func CheckAndSendRetryMessage(ctx context.Context, dTask *task.DownloadTask) {

--- a/pp/event/download_file_wrong.go
+++ b/pp/event/download_file_wrong.go
@@ -2,6 +2,8 @@ package event
 
 import (
 	"context"
+	"strings"
+	"time"
 
 	"github.com/stratosnet/sds/framework/core"
 	"github.com/stratosnet/sds/framework/msg/header"
@@ -12,6 +14,11 @@ import (
 	"github.com/stratosnet/sds/pp/requests"
 	"github.com/stratosnet/sds/pp/task"
 	"github.com/stratosnet/sds/sds-msg/protos"
+)
+
+const (
+	ResendFailedDownloadDelay     = 5  // Seconds
+	ResendFailedDownloadTimeLimit = 30 // Seconds. If this time has elapsed since the start of the download task, don't resend the ReqDownloadFileWrong
 )
 
 func CheckAndSendRetryMessage(ctx context.Context, dTask *task.DownloadTask) {
@@ -30,52 +37,61 @@ func CheckAndSendRetryMessage(ctx context.Context, dTask *task.DownloadTask) {
 	}
 }
 
-// RspFileStorageInfo SP-PP , PP-P
 func RspDownloadFileWrong(ctx context.Context, conn core.WriteCloser) {
-	// PP check whether itself is the storage PP, if not transfer
 	utils.Log("get RspDownloadFileWrong")
 	var target protos.RspFileStorageInfo
 	if err := VerifyMessage(ctx, header.RspDownloadFileWrong, &target); err != nil {
 		utils.ErrorLog("failed verifying the message, ", err.Error())
 		return
 	}
-	if requests.UnmarshalData(ctx, &target) {
 
-		fileReqId, found := getFileReqIdFromContext(ctx)
-		if !found {
-			pp.DebugLog(ctx, "cannot find the original file request id")
+	if !requests.UnmarshalData(ctx, &target) {
+		return
+	}
+
+	fileReqId, found := getFileReqIdFromContext(ctx)
+	if !found {
+		pp.DebugLog(ctx, "cannot find the original file request id")
+		return
+	}
+
+	pp.DebugLog(ctx, "file hash", target.FileHash)
+	if target.Result.State == protos.ResultState_RES_SUCCESS {
+		pp.Log(ctx, "download starts: ")
+		dTask, ok := task.GetDownloadTask(target.FileHash + target.WalletAddress + fileReqId)
+		if !ok {
+			pp.DebugLog(ctx, "cannot find the download task")
 			return
 		}
-		pp.DebugLog(ctx, "file hash", target.FileHash)
-		if target.Result.State == protos.ResultState_RES_SUCCESS {
-			pp.Log(ctx, "download starts: ")
-			dTask, ok := task.GetDownloadTask(target.FileHash + target.WalletAddress + fileReqId)
-			if !ok {
-				pp.DebugLog(ctx, "cannot find the download task")
-				return
-			}
-			dTask.RefreshTask(&target)
-			if _, ok := task.DownloadSpeedOfProgress.Load(target.FileHash + fileReqId); !ok {
-				pp.Log(ctx, "download has stopped")
-				return
-			}
-			for _, slice := range target.SliceInfo {
-				utils.DebugLog("taskid ======= ", slice.TaskId)
-				if file.CheckSliceExisting(target.FileHash, target.FileName, slice.SliceStorageInfo.SliceHash, fileReqId) {
-					pp.Log(ctx, "slice exist already,", slice.SliceStorageInfo.SliceHash)
-					setDownloadSliceSuccess(ctx, slice.SliceStorageInfo.SliceHash, dTask)
-					task.DownloadProgress(ctx, target.FileHash, fileReqId, slice.SliceOffset.SliceOffsetEnd-slice.SliceOffset.SliceOffsetStart)
-				} else {
-					dTask.AddFailedSlice(slice.SliceStorageInfo.SliceHash)
-					task.DownloadSliceProgress.Store(slice.TaskId+slice.SliceStorageInfo.SliceHash+fileReqId, uint64(0))
-					req := requests.ReqDownloadSliceData(ctx, &target, slice)
-					newCtx := createAndRegisterSliceReqId(ctx, fileReqId)
-					SendReqDownloadSlice(newCtx, target.FileHash, slice, req, fileReqId)
-				}
-			}
-		} else {
-			task.DeleteDownloadTask(target.FileHash, target.WalletAddress, task.LOCAL_REQID)
-			task.DownloadResult(ctx, target.FileHash, false, target.Result.Msg)
+		dTask.RefreshTask(&target)
+		if _, ok := task.DownloadSpeedOfProgress.Load(target.FileHash + fileReqId); !ok {
+			pp.Log(ctx, "download has stopped")
+			return
 		}
+		for _, slice := range target.SliceInfo {
+			utils.DebugLog("taskid ======= ", slice.TaskId)
+			if file.CheckSliceExisting(target.FileHash, target.FileName, slice.SliceStorageInfo.SliceHash, fileReqId) {
+				pp.Log(ctx, "slice exist already,", slice.SliceStorageInfo.SliceHash)
+				setDownloadSliceSuccess(ctx, slice.SliceStorageInfo.SliceHash, dTask)
+				task.DownloadProgress(ctx, target.FileHash, fileReqId, slice.SliceOffset.SliceOffsetEnd-slice.SliceOffset.SliceOffsetStart)
+			} else {
+				dTask.AddFailedSlice(slice.SliceStorageInfo.SliceHash)
+				task.DownloadSliceProgress.Store(slice.TaskId+slice.SliceStorageInfo.SliceHash+fileReqId, uint64(0))
+				req := requests.ReqDownloadSliceData(ctx, &target, slice)
+				newCtx := createAndRegisterSliceReqId(ctx, fileReqId)
+				SendReqDownloadSlice(newCtx, target.FileHash, slice, req, fileReqId)
+			}
+		}
+	} else {
+		dTask, ok := task.GetDownloadTask(target.FileHash + target.WalletAddress + fileReqId)
+		if ok && strings.Contains(target.Result.Msg, "cannot find the task") && time.Now().Unix() < dTask.StartTimestamp+ResendFailedDownloadTimeLimit {
+			taskMonitorClock.AddJobWithInterval(time.Second*ResendFailedDownloadDelay, func() {
+				CheckAndSendRetryMessage(ctx, dTask)
+			})
+			return
+		}
+
+		task.DeleteDownloadTask(target.FileHash, target.WalletAddress, task.LOCAL_REQID)
+		task.DownloadResult(ctx, target.FileHash, false, target.Result.Msg)
 	}
 }

--- a/pp/task/download_task.go
+++ b/pp/task/download_task.go
@@ -67,16 +67,17 @@ type VideoCacheTask struct {
 
 // DownloadTask signal task convert sliceHash list to map
 type DownloadTask struct {
-	TaskId        string // file task id
-	WalletAddress string
-	FileHash      string
-	VisitCer      string
-	sliceInfo     map[string]*protos.DownloadSliceInfo
-	FailedSlice   map[string]bool
-	SuccessSlice  map[string]bool
-	FailedPPNodes map[string]*protos.PPBaseInfo
-	SliceCount    int
-	taskMutex     sync.RWMutex
+	TaskId         string // file task id
+	WalletAddress  string
+	FileHash       string
+	VisitCer       string
+	sliceInfo      map[string]*protos.DownloadSliceInfo
+	FailedSlice    map[string]bool
+	SuccessSlice   map[string]bool
+	FailedPPNodes  map[string]*protos.PPBaseInfo
+	SliceCount     int
+	StartTimestamp int64
+	taskMutex      sync.RWMutex
 }
 
 func (task *DownloadTask) DeleteSliceInfo(sliceHash string) {
@@ -154,15 +155,16 @@ func AddDownloadTask(target *protos.RspFileStorageInfo) {
 		failedSlice[key] = true
 	}
 	dTask := &DownloadTask{
-		WalletAddress: target.WalletAddress,
-		FileHash:      target.FileHash,
-		VisitCer:      target.VisitCer,
-		sliceInfo:     SliceInfoMap,
-		FailedSlice:   failedSlice,
-		SuccessSlice:  make(map[string]bool),
-		FailedPPNodes: make(map[string]*protos.PPBaseInfo),
-		SliceCount:    len(target.SliceInfo),
-		TaskId:        target.TaskId,
+		WalletAddress:  target.WalletAddress,
+		FileHash:       target.FileHash,
+		VisitCer:       target.VisitCer,
+		sliceInfo:      SliceInfoMap,
+		FailedSlice:    failedSlice,
+		SuccessSlice:   make(map[string]bool),
+		FailedPPNodes:  make(map[string]*protos.PPBaseInfo),
+		SliceCount:     len(target.SliceInfo),
+		TaskId:         target.TaskId,
+		StartTimestamp: time.Now().Unix(),
 	}
 	DownloadTaskMap.Store((target.FileHash + target.WalletAddress + target.ReqId), dTask)
 	metrics.TaskCount.WithLabelValues("download").Inc()


### PR DESCRIPTION
https://qsn.atlassian.net/browse/ST-447

- When `ReqDownloadFileWrong` fails due to the download task not being created yet, resend the `ReqDownloadFileWrong` request