### PR TITLE
fix/ST-528 initial beneficiary address

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stratosnet/sds/framework v0.0.0-20241001145417-96154d80c375
 	github.com/stratosnet/sds/sds-msg v0.0.0-20241001145417-96154d80c375
-	github.com/stratosnet/sds/tx-client v0.0.0-20241001145417-96154d80c375
+	github.com/stratosnet/sds/tx-client v0.0.0-20241008122654-7783d84cbea7
 	github.com/stratosnet/stratos-chain/api v0.0.0-20240509211914-ee516857645d
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	google.golang.org/protobuf v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/stratosnet/sds/framework v0.0.0-20241001145417-96154d80c375 h1:5fJWI9
 github.com/stratosnet/sds/framework v0.0.0-20241001145417-96154d80c375/go.mod h1:nuOItdDWY4QNxvHQQnc8SkIjikccc55iFOmGB8MBCg8=
 github.com/stratosnet/sds/sds-msg v0.0.0-20241001145417-96154d80c375 h1:YZPDgfSUnZQZoU6GY3jWy2M5MeS3FqYe6Y2lJZjDdDQ=
 github.com/stratosnet/sds/sds-msg v0.0.0-20241001145417-96154d80c375/go.mod h1:Kka5l0sHUjpWmCnGCZieLs/6hrprDITb0me+oiljBe4=
-github.com/stratosnet/sds/tx-client v0.0.0-20241001145417-96154d80c375 h1:CUmMnJb953yU3V5qefU1sBOXIbcgBr06/d4vPJ8Ya1o=
-github.com/stratosnet/sds/tx-client v0.0.0-20241001145417-96154d80c375/go.mod h1:OtsXl6Hqtimw506uvPNRK949jY+/MxjTLkmbpcr8Qm8=
+github.com/stratosnet/sds/tx-client v0.0.0-20241008122654-7783d84cbea7 h1:OnOuy+yEklBvm39gqKMPXvG/u6VLKGRmq6QVU0EvRlc=
+github.com/stratosnet/sds/tx-client v0.0.0-20241008122654-7783d84cbea7/go.mod h1:5l47+gxJ3RmLEaohS/zWtE/OeG2m7UGRVF2o7VRGJnk=
 github.com/stratosnet/stratos-chain/api v0.0.0-20240509211914-ee516857645d h1:P8M04b8QW8L7Yne97+SkztbUVTa0j/7gCstI4xaIMKo=
 github.com/stratosnet/stratos-chain/api v0.0.0-20240509211914-ee516857645d/go.mod h1:FN6crwtoVjf2errz8Nsj0y/zRxuIRtxs5w8qLHKVBqA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pp/event/data.go
+++ b/pp/event/data.go
@@ -21,7 +21,12 @@ func reqActivateData(ctx context.Context, amount txclienttypes.Coin, txFee txcli
 		return nil, err
 	}
 
-	txMsg, err := txclienttx.BuildCreateResourceNodeMsg(msgtypes.STORAGE, p2pserver.GetP2pServer(ctx).GetP2PPublicKey(), amount, ownerAddress)
+	beneficiaryAddress, err := fwtypes.WalletAddressFromBech32(setting.BeneficiaryAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	txMsg, err := txclienttx.BuildCreateResourceNodeMsg(msgtypes.STORAGE, p2pserver.GetP2pServer(ctx).GetP2PPublicKey(), amount, ownerAddress, beneficiaryAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/relayer/server/rpc_api.go
+++ b/relayer/server/rpc_api.go
@@ -23,6 +23,10 @@ func (api *rpcApi) Account(ctx context.Context, walletAddress string) (*authv1be
 	return grpc.QueryAccount(walletAddress)
 }
 
+func (api *rpcApi) ResourceNode(ctx context.Context, p2pAddress string) (*registerv1.ResourceNode, error) {
+	return grpc.QueryResourceNode(p2pAddress)
+}
+
 func (api *rpcApi) ResourceNodeState(ctx context.Context, p2pAddress string) (state types.ResourceNodeState, err error) {
 	return grpc.QueryResourceNodeState(p2pAddress)
 }

--- a/tx-client/tx/msg_builder.go
+++ b/tx-client/tx/msg_builder.go
@@ -120,7 +120,7 @@ func BuildUpdateEffectiveDepositMsg(spP2pAddress []fwtypes.P2PAddress, spWalletA
 // Stratos-chain 'register' module
 
 func BuildCreateResourceNodeMsg(nodeType msgtypes.NodeType, p2pPubKey fwcryptotypes.PubKey, depositAmount txclienttypes.Coin,
-	ownerAddress fwtypes.WalletAddress) (*registerv1.MsgCreateResourceNode, error) {
+	ownerAddress, beneficiaryAddress fwtypes.WalletAddress) (*registerv1.MsgCreateResourceNode, error) {
 
 	if nodeType == 0 {
 		nodeType = msgtypes.STORAGE
@@ -141,7 +141,8 @@ func BuildCreateResourceNodeMsg(nodeType msgtypes.NodeType, p2pPubKey fwcryptoty
 			Denom:  depositAmount.Denom,
 			Amount: depositAmount.Amount.String(),
 		},
-		OwnerAddress: ownerAddress.String(),
+		OwnerAddress:       ownerAddress.String(),
+		BeneficiaryAddress: beneficiaryAddress.String(),
 		Description: &registerv1.Description{
 			Moniker: p2pAddress.String(),
 		},


### PR DESCRIPTION
https://qsn.atlassian.net/browse/ST-528

- sent beneficiary address to stchain when first activating the node
- add warning to use `updateinfo` when beneficiary address is different in config and in stchain
- add `query_resourceNode` to relayer RPC API