### PR TITLE
hotfix/ hashring panic in RemoveNode

### DIFF
--- a/framework/utils/hashring/hashring.go
+++ b/framework/utils/hashring/hashring.go
@@ -104,8 +104,8 @@ func (r *HashRing) RemoveNode(ID string) {
 		return
 	}
 
-	delete(r.nodes, ID)
 	r.removeFromOnlineList(node)
+	delete(r.nodes, ID)
 }
 
 func (r *HashRing) Node(ID string) *Node {
@@ -154,8 +154,12 @@ func (r *HashRing) removeFromOnlineList(node *Node) {
 		if !ok {
 			return
 		}
-		r.onlineNodes[node.onlineIndex] = lastElement
-		r.nodes[lastElement.id].onlineIndex = node.onlineIndex
+		if lastElement.id != node.id {
+			// node is not the last element. Switch both nodes
+			r.onlineNodes[node.onlineIndex] = lastElement
+			r.nodes[lastElement.id].onlineIndex = node.onlineIndex
+		}
+		// Discard last element
 		r.onlineNodes = r.onlineNodes[:len(r.onlineNodes)-1]
 	}
 

--- a/framework/utils/hashring/hashring_test.go
+++ b/framework/utils/hashring/hashring_test.go
@@ -56,6 +56,41 @@ func TestHashringNodeCount(t *testing.T) {
 	require.Equal(t, uint32(0), ring.NodeOkCount())
 }
 
+func TestHashringRemoveNode(t *testing.T) {
+	ring := New()
+	ring.AddNode("node1", &Node{})
+	ring.RemoveNode("node1")
+	require.Equal(t, uint32(0), ring.NodeCount())
+
+	ring.AddNode("node1", &Node{})
+	ring.SetOnline("node1")
+	ring.RemoveNode("node1")
+	require.Equal(t, uint32(0), ring.NodeCount())
+	require.Equal(t, uint32(0), ring.NodeOkCount())
+
+	ring.AddNode("node1", &Node{})
+	ring.AddNode("node2", &Node{})
+	ring.SetOnline("node1")
+	ring.SetOnline("node2")
+	ring.RemoveNode("node1")
+	require.Equal(t, uint32(1), ring.NodeCount())
+	require.Equal(t, uint32(1), ring.NodeOkCount())
+	ring.RemoveNode("node2")
+	require.Equal(t, uint32(0), ring.NodeCount())
+	require.Equal(t, uint32(0), ring.NodeOkCount())
+
+	ring.AddNode("node1", &Node{})
+	ring.AddNode("node2", &Node{})
+	ring.SetOnline("node1")
+	ring.SetOnline("node2")
+	ring.RemoveNode("node2")
+	require.Equal(t, uint32(1), ring.NodeCount())
+	require.Equal(t, uint32(1), ring.NodeOkCount())
+	ring.RemoveNode("node1")
+	require.Equal(t, uint32(0), ring.NodeCount())
+	require.Equal(t, uint32(0), ring.NodeOkCount())
+}
+
 func TestRandomTrends(t *testing.T) {
 	baseId := "stsdsp2p1faej5w4q6hgnt0ft598dlm408g4p747ymg5jq6"
 	numNode := 10


### PR DESCRIPTION
- fixed panic in hashring `RemoveNode`, when there are at least 2 online nodes, and `RemoveNode` is called on the last online node in the list
- fixed hashring concurrency issue when reading from internal map