### PR TITLE
fix/ST-762 utils.FormatError support all error types

### DIFF
--- a/framework/utils/error.go
+++ b/framework/utils/error.go
@@ -20,7 +20,12 @@ func (e ErrUndefined) Error() string {
 }
 
 type stackTracer interface {
+	Error() string
 	StackTrace() errors.StackTrace
+}
+
+type unwrapper interface {
+	Unwrap() error
 }
 
 func FormatError(err error) string {
@@ -29,15 +34,60 @@ func FormatError(err error) string {
 	}
 
 	str := err.Error()
-	cause := errors.Cause(err)
-	if causeStack, ok := cause.(stackTracer); ok {
-		str += "  "
-		for i, f := range causeStack.StackTrace() {
-			if i != 0 {
-				str += "->"
-			}
-			str += fmt.Sprintf("[%n|%s:%d]", f, f, f)
+
+	var topFrames, trace []errors.Frame
+	var errWithTrace stackTracer
+	var ok bool
+	for {
+		errWithTrace, ok = err.(stackTracer)
+		if !ok {
+			break
+		}
+		trace = errWithTrace.StackTrace()
+		topFrames = append(topFrames, trace[0]) // Save the frame where Wrap is called
+		err = unwrapStackTracer(errWithTrace)
+	}
+
+	if len(topFrames) > 0 {
+		topFrames = topFrames[:len(topFrames)-1] // the last top frame is the first frame from trace
+	}
+	if len(trace) > 2 {
+		trace = trace[:len(trace)-2] // skip what calls our main function (main|proc.go:271 and goexit|asm_amd64.s:1695)
+	}
+	if len(trace) > 5 {
+		trace = trace[:5] // if stack trace is still too long, only keep first 5 locations
+	}
+	trace = append(topFrames, trace...)
+
+	if len(topFrames) > 0 {
+		str += ": wrapped by "
+	}
+	for i, f := range trace {
+		if i == len(topFrames) {
+			str += " caused by "
+		} else if i != 0 {
+			str += "->"
+		}
+		str += fmt.Sprintf("[%n|%v]", f, f)
+	}
+
+	return str
+}
+
+// unwrapStackTracer calls Unwrap on the given stackTracer error until we reach another stackTracer. Returns nil if one can't be found
+func unwrapStackTracer(err stackTracer) error {
+	var curErr error = err
+	for {
+		if curErr == nil {
+			return nil
+		}
+		unwrapperErr, ok := curErr.(unwrapper)
+		if !ok {
+			return nil
+		}
+		curErr = unwrapperErr.Unwrap()
+		if _, ok = curErr.(stackTracer); ok {
+			return curErr
 		}
 	}
-	return str
 }

--- a/framework/utils/error.go
+++ b/framework/utils/error.go
@@ -60,15 +60,15 @@ func FormatError(err error) string {
 	trace = append(topFrames, trace...)
 
 	if len(topFrames) > 0 {
-		str += ": wrapped by "
+		str += "  [WRAP]"
 	}
 	for i, f := range trace {
 		if i == len(topFrames) {
-			str += " caused by "
+			str += "  [CAUSE]"
 		} else if i != 0 {
 			str += "->"
 		}
-		str += fmt.Sprintf("[%n|%v]", f, f)
+		str += fmt.Sprintf("(%n|%v)", f, f)
 	}
 
 	return str


### PR DESCRIPTION
https://qsn.atlassian.net/browse/ST-762

- fixed `utils.FormatError` so it supports all error types (no matter the type of the root cause)
- added stack trace for the places where `errors.Wrap` is called

#### Examples using `utils.ErrorLog(utils.FormatError(err))`
- single wrapped error
```
[ERROR] 2025/01/17 13:04:14.156636 playground.go:19: layer one: root  [WRAP](f1|playground.go:45)  [CAUSE](f1|playground.go:43)->(main|playground.go:18)
```
- single wrapped error from other packages
```
[ERROR] 2025/01/17 13:05:59.001364 playground.go:20: layer one: no rows in result set  [CAUSE](f1|playground.go:46)->(main|playground.go:19)
```
- double wrapped error 
```
[ERROR] 2025/01/17 13:05:21.858214 playground.go:19: layer two: layer one: root  [WRAP](f2|playground.go:39)->(f1|playground.go:45)  [CAUSE](f1|playground.go:43)->(f2|playground.go:38)->(main|playground.go:18)
```
- double wrapped error from other packages
```
[ERROR] 2025/01/17 13:06:34.630459 playground.go:20: layer two: layer one: no rows in result set  [WRAP](f2|playground.go:40)  [CAUSE](f1|playground.go:46)->(f2|playground.go:39)->(main|playground.go:19)
```
